### PR TITLE
docs: Fix Sphinx warnings and additional cleanups

### DIFF
--- a/docs/API-Overview.rest
+++ b/docs/API-Overview.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
@@ -9,12 +9,6 @@
 =============
 API Overview
 =============
-
-
-
-
-
-
 
 Why iLO RESTful API?
 ====================
@@ -37,7 +31,6 @@ blades, as well as newer types of systems like Moonshot. This advantage comes be
 model is designed to self-describe the service’s capabilities to the client and has room for flexibility
 designed in from the start.
 
-
 Resource operations
 ===================
 
@@ -49,10 +42,10 @@ manager, is not changed.
 +------------------------+---------------------------------+-----------------------------------------------------------+
 | Operation              | HTTP Verb                       | Description                                               |
 +========================+=================================+===========================================================+
-|       Create           | POST resource URI (payload =    | Create new resources. A synchronous POST returns the newly|         
+|       Create           | POST resource URI (payload =    | Create new resources. A synchronous POST returns the newly|
 |                        | resource data)                  | created resource.                                         |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-|        Read            | GET resource URI                | Returns the requested resource representations.           |        
+|        Read            | GET resource URI                | Returns the requested resource representations.           |
 +------------------------+---------------------------------+-----------------------------------------------------------+
 |        Update          | PATCH resource URI (payload =   | Updates an existing resource. You can only PATCH          |
 |                        | update data)                    | properties that are marked readonly = false in the schema.|
@@ -66,11 +59,9 @@ Return codes
 +------------------------+---------------------------------------------------------------------------------------------+
 | Return code            | Description                                                                                 |
 +========================+=================================+===========================================================+
-| 2xx                    | Successful operation.                                                                       |         
+| 2xx                    | Successful operation.                                                                       |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-| 4xx                    | Client-side error with error message returned.                                              |        
+| 4xx                    | Client-side error with error message returned.                                              |
 +------------------------+---------------------------------+-----------------------------------------------------------+
 | 5xx                    | iLO error with error message returned.                                                      |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-
-

--- a/docs/Examples.rest
+++ b/docs/Examples.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
@@ -10,24 +10,16 @@
 Examples
 ========
 
-
-
-|
-
-
 RestfulApiExamples.py and RedfishAPiExamples.py modules contain few examples for performing different iLO tasks using legacy RESTful API and Redfish API respectively. The examples in this page are legacy RESTful examples and are very similar to their  Redfish equivalents. The HPE RESTful API 1.x expresses the root Uniform Resource Identifier (URI) protocol version as “**/rest/v1**”. Redfish 1.0 expresses
 the starting URI as “**/redfish/v1/**”.
 
 Redfish changes the linking between resources, for example  “**href**” is renamed to “**@odata.id**”. For more information about Redfish implementation click `here <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_ .
 
-
-
 The following examples can all be used as guidance for `managing iLO using iLO RESTful API <https://github.com/HewlettPackard/python-ilorest-library/blob/master/docs/Managing_HPE_Servers_Using_RESTful_API.md>`_.
-
 
 .. toctree::
    :maxdepth: 1
-   
+
    ex1_get_resource_directory
    ex2_get_base_registry
    ex3_change_bios_setting
@@ -76,5 +68,3 @@ The following examples can all be used as guidance for `managing iLO using iLO R
    ex46_get_ahs_data
    ex47_clear_ahs_data
    ex48_set_bios_password
-   
-   

--- a/docs/Examples.rest
+++ b/docs/Examples.rest
@@ -10,15 +10,22 @@
 Examples
 ========
 
-RestfulApiExamples.py and RedfishAPiExamples.py modules contain few examples for performing different iLO tasks using legacy RESTful API and Redfish API respectively. The examples in this page are legacy RESTful examples and are very similar to their  Redfish equivalents. The HPE RESTful API 1.x expresses the root Uniform Resource Identifier (URI) protocol version as “**/rest/v1**”. Redfish 1.0 expresses
-the starting URI as “**/redfish/v1/**”.
+RestfulApiExamples.py and RedfishAPiExamples.py modules contain few examples
+for performing different iLO tasks using legacy RESTful API and Redfish API
+respectively. The examples in this page are legacy RESTful examples and are
+very similar to their Redfish equivalents. The HPE RESTful API 1.x expresses
+the root Uniform Resource Identifier (URI) protocol version as “**/rest/v1**”.
+Redfish 1.0 expresses the starting URI as “**/redfish/v1/**”.
 
-Redfish changes the linking between resources, for example  “**href**” is renamed to “**@odata.id**”. For more information about Redfish implementation click `here <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_ .
+Redfish changes the linking between resources, for example “**href**” is
+renamed to “**@odata.id**”. For more information about Redfish implementation
+click `here <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_ .
 
-The following examples can all be used as guidance for `managing iLO using iLO RESTful API <https://github.com/HewlettPackard/python-ilorest-library/blob/master/docs/Managing_HPE_Servers_Using_RESTful_API.md>`_.
+The following examples can all be used as guidance for `managing iLO using iLO
+RESTful API
+<https://github.com/HewlettPackard/python-ilorest-library/blob/master/docs/Managing_HPE_Servers_Using_RESTful_API.md>`_.
 
-.. toctree::
-   :maxdepth: 1
+.. toctree:: :maxdepth: 1
 
    ex1_get_resource_directory
    ex2_get_base_registry

--- a/docs/Frequently-Asked-Questions.rest
+++ b/docs/Frequently-Asked-Questions.rest
@@ -1,10 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
-
 
 Frequently Asked Questions
 ==========================
@@ -15,6 +12,3 @@ Q1: What is the difference between REST and Redfish API?
 Representational State Transfer(REST) is a web based software architectural style consisting a set of constraints that focus on a system's resource. HPE REST library performs the basic HTTP operations GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as the Engine of Application) REST architecture. RESTful  typically  refers to web services implementing REST architecture.
 
 Redfish API uses a hypermedia data model OData(Open Data Protocol) v4 represented within a RESTful interface. OData is a specific implementation of REST architecture which allows resources indentified using URIs and defined in abstract data model. Since it is based on OData v4, Redfish implementation requires the starting metadata OData header to be version 4. Redfish changes the linking between resources. Where the HPE Restful URIs places all link as "href" inside a "links" sub-object, Redfish changes "**href**" to "**@odata.id**", "**links**" sub-objects to "**Links**". For more information click on `Redfish <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_ API.
- 
-
-

--- a/docs/Frequently-Asked-Questions.rest
+++ b/docs/Frequently-Asked-Questions.rest
@@ -9,6 +9,20 @@ Frequently Asked Questions
 Q1: What is the difference between REST and Redfish API?
 --------------------------------------------------------
 
-Representational State Transfer(REST) is a web based software architectural style consisting a set of constraints that focus on a system's resource. HPE REST library performs the basic HTTP operations GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as the Engine of Application) REST architecture. RESTful  typically  refers to web services implementing REST architecture.
+Representational State Transfer(REST) is a web based software architectural
+style consisting a set of constraints that focus on a system's resource. HPE
+REST library performs the basic HTTP operations GET, POST, PUT, PATCH and
+DELETE on resources using the HATEOS (Hypermedia as the Engine of Application)
+REST architecture. RESTful typically refers to web services implementing REST
+architecture.
 
-Redfish API uses a hypermedia data model OData(Open Data Protocol) v4 represented within a RESTful interface. OData is a specific implementation of REST architecture which allows resources indentified using URIs and defined in abstract data model. Since it is based on OData v4, Redfish implementation requires the starting metadata OData header to be version 4. Redfish changes the linking between resources. Where the HPE Restful URIs places all link as "href" inside a "links" sub-object, Redfish changes "**href**" to "**@odata.id**", "**links**" sub-objects to "**Links**". For more information click on `Redfish <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_ API.
+Redfish API uses a hypermedia data model OData(Open Data Protocol) v4
+represented within a RESTful interface. OData is a specific implementation of
+REST architecture which allows resources indentified using URIs and defined in
+abstract data model. Since it is based on OData v4, Redfish implementation
+requires the starting metadata OData header to be version 4. Redfish changes
+the linking between resources. Where the HPE Restful URIs places all link as
+"href" inside a "links" sub-object, Redfish changes "**href**" to
+"**@odata.id**", "**links**" sub-objects to "**Links**". For more information
+click on `Redfish <http://www8.hp.com/h20195/v2/GetPDF.aspx/4AA6-1727ENW.pdf>`_
+API.

--- a/docs/Installation-Guide.rest
+++ b/docs/Installation-Guide.rest
@@ -13,12 +13,17 @@ Installing Python 2.7.x
 On Windows
 ----------
 
-First download the latest version of Python2.7.x from `here <https://www.python.org/downloads/windows/>`_.
-The Windows version is provided as an MSI package. Double click the downloaded file, MSI package format allows Windows Administrators to automate installation with their standard tools.
+First download the latest version of Python2.7.x from `here
+<https://www.python.org/downloads/windows/>`_.
+The Windows version is provided as an MSI package. Double click the downloaded
+file, MSI package format allows Windows Administrators to automate installation
+with their standard tools.
 
-By default, Python is installed to a directory with the version number embedded, e.g. Python version 2.7 will install at *C:\\Python27\\* .
+By default, Python is installed to a directory with the version number
+embedded, e.g. Python version 2.7 will install at *C:\\Python27\\* .
 
-Assuming that Python is installed at *C:\\Python27\\*, add the following to **PATH** .
+Assuming that Python is installed at *C:\\Python27\\*, add the following to
+**PATH** .
 
 ::
 
@@ -27,14 +32,16 @@ Assuming that Python is installed at *C:\\Python27\\*, add the following to **PA
 On Linux
 --------
 
-The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu came with Python 2.7 out of the box.
-To check which version of Python is installed , from command prompt run
+The latest versions of CentOS, Fedora, Redhat Enterprise (RHEL) and Ubuntu came
+with Python 2.7 out of the box. To check which version of Python is installed,
+from command prompt run
 
 ::
 
  $ python --version
 
-In order to install Python from command line, first download the Python by running the following:
+In order to install Python from command line, first download the Python by
+running the following:
 
 ::
 
@@ -42,7 +49,8 @@ In order to install Python from command line, first download the Python by runni
  tar -xzf Python-2.7.11.tgz
  cd Python-2.7.11
 
-Next read the README file to figure out the installation process, a typical installation may look like this
+Next read the README file to figure out the installation process, a typical
+installation may look like this
 
 ::
 
@@ -56,7 +64,9 @@ Checkout the Python iLO RESTful library
 Using SVN (Subversion)
 ----------------------
 
-Assuming that SVN is already installed in your system and it is already in System Path, execute the following command from the directory where you want to copy the source.
+Assuming that SVN is already installed in your system and it is already in
+System Path, execute the following command from the directory where you want to
+copy the source.
 
 ::
 
@@ -65,7 +75,8 @@ Assuming that SVN is already installed in your system and it is already in Syste
 Using GIT
 ---------
 
-Execute the following command from the directory where you want to copy the source.
+Execute the following command from the directory where you want to copy the
+source.
 
 ::
 
@@ -74,7 +85,10 @@ Execute the following command from the directory where you want to copy the sour
 Building and installing HP REST library
 =======================================
 
-First download the redfish.zip file from the github. Next unzip redfish.zip file to redfish directory and from the command prompt go to the directory. Execute the following commands in order to install redfish (assuming the version is 2.1.0).
+First download the redfish.zip file from the github. Next unzip redfish.zip
+file to redfish directory and from the command prompt go to the directory.
+Execute the following commands in order to install redfish (assuming the
+version is 2.1.0).
 
 ::
 
@@ -82,4 +96,5 @@ First download the redfish.zip file from the github. Next unzip redfish.zip file
  cd dist
  pip install --upgrade python-ilorest-library-2.1.0.zip
 
-A successful installation will display that python-ilorest-library-x.x.x and the dependencies have been successfully installed.
+A successful installation will display that python-ilorest-library-x.x.x and
+the dependencies have been successfully installed.

--- a/docs/Installation-Guide.rest
+++ b/docs/Installation-Guide.rest
@@ -1,16 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 ==================
 Installation Guide
 ==================
-
-
-
-
-
 
 Installing Python 2.7.x
 =======================
@@ -18,7 +13,7 @@ Installing Python 2.7.x
 On Windows
 ----------
 
-First download the latest version of Python2.7.x from `here <https://www.python.org/downloads/windows/>`_.               
+First download the latest version of Python2.7.x from `here <https://www.python.org/downloads/windows/>`_.
 The Windows version is provided as an MSI package. Double click the downloaded file, MSI package format allows Windows Administrators to automate installation with their standard tools.
 
 By default, Python is installed to a directory with the version number embedded, e.g. Python version 2.7 will install at *C:\\Python27\\* .
@@ -27,13 +22,7 @@ Assuming that Python is installed at *C:\\Python27\\*, add the following to **PA
 
 ::
 
-   C:\Python27\;C:\Python27\Scripts\
-
-::
-
-
-
-
+ C:\Python27\;C:\Python27\Scripts\
 
 On Linux
 --------
@@ -43,35 +32,26 @@ To check which version of Python is installed , from command prompt run
 
 ::
 
-  $ python --version
-
-::
+ $ python --version
 
 In order to install Python from command line, first download the Python by running the following:
 
 ::
 
-   wget --no-check-certificate https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz
-   tar -xzf Python-2.7.11.tgz  
-   cd Python-2.7.11
-
-::
+ wget --no-check-certificate https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz
+ tar -xzf Python-2.7.11.tgz
+ cd Python-2.7.11
 
 Next read the README file to figure out the installation process, a typical installation may look like this
 
 ::
 
-  ./configure
-  make
-  sudo make install
-
-
-::
-
+ ./configure
+ make
+ sudo make install
 
 Checkout the Python iLO RESTful library
 =======================================
-
 
 Using SVN (Subversion)
 ----------------------
@@ -80,9 +60,7 @@ Assuming that SVN is already installed in your system and it is already in Syste
 
 ::
 
-  svn checkout https://github.com/HewlettPackard/python-ilorest-library.git
-  
-::
+ svn checkout https://github.com/HewlettPackard/python-ilorest-library.git
 
 Using GIT
 ---------
@@ -91,26 +69,17 @@ Execute the following command from the directory where you want to copy the sour
 
 ::
 
-  git clone https://github.com/HewlettPackard/python-ilorest-library.git
-  
-::
-
-
-
-
-
+ git clone https://github.com/HewlettPackard/python-ilorest-library.git
 
 Building and installing HP REST library
-===================================
+=======================================
 
 First download the redfish.zip file from the github. Next unzip redfish.zip file to redfish directory and from the command prompt go to the directory. Execute the following commands in order to install redfish (assuming the version is 2.1.0).
 
 ::
 
-  python setup.py sdist --formats=zip
-  cd dist
-  pip install --upgrade python-ilorest-library-2.1.0.zip
+ python setup.py sdist --formats=zip
+ cd dist
+ pip install --upgrade python-ilorest-library-2.1.0.zip
 
-::
-
-A successful installation will display that python-ilorest-library-x.x.x and the dependencies have been successfully installed.  
+A successful installation will display that python-ilorest-library-x.x.x and the dependencies have been successfully installed.

--- a/docs/Overview.rest
+++ b/docs/Overview.rest
@@ -1,7 +1,7 @@
 
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
@@ -11,11 +11,8 @@
 Overview
 ========
 
-
-
-
 Why HPE iLO RESTful SDK?
------------------------
+------------------------
 
 This HPE RESTful API for iLO will become the main management API for iLO and iLO Chassis Manager
 based HPE servers. Its feature set will become larger than the existing iLO XML API (RIBCL) and IPMI
@@ -35,7 +32,6 @@ blades, as well as newer types of systems like Moonshot. This advantage comes be
 model is designed to self-describe the service’s capabilities to the client and has room for flexibility
 designed in from the start.
 
-
 Resource operations
 -------------------
 
@@ -47,10 +43,10 @@ manager, is not changed.
 +------------------------+---------------------------------+-----------------------------------------------------------+
 | Operation              | HTTP Verb                       | Description                                               |
 +========================+=================================+===========================================================+
-|       Create           | POST resource URI (payload =    | Create new resources. A synchronous POST returns the newly|         
+|       Create           | POST resource URI (payload =    | Create new resources. A synchronous POST returns the newly|
 |                        | resource data)                  | created resource.                                         |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-|        Read            | GET resource URI                | Returns the requested resource representations.           |        
+|        Read            | GET resource URI                | Returns the requested resource representations.           |
 +------------------------+---------------------------------+-----------------------------------------------------------+
 |        Update          | PATCH resource URI (payload =   | Updates an existing resource. You can only PATCH          |
 |                        | update data)                    | properties that are marked readonly = false in the schema.|
@@ -64,11 +60,9 @@ Return codes
 +------------------------+---------------------------------------------------------------------------------------------+
 | Return code            | Description                                                                                 |
 +========================+=================================+===========================================================+
-| 2xx                    | Successful operation.                                                                       |         
+| 2xx                    | Successful operation.                                                                       |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-| 4xx                    | Client-side error with error message returned.                                              |        
+| 4xx                    | Client-side error with error message returned.                                              |
 +------------------------+---------------------------------+-----------------------------------------------------------+
 | 5xx                    | iLO error with error message returned.                                                      |
 +------------------------+---------------------------------+-----------------------------------------------------------+
-
-

--- a/docs/Overview.rest
+++ b/docs/Overview.rest
@@ -14,31 +14,35 @@ Overview
 Why HPE iLO RESTful SDK?
 ------------------------
 
-This HPE RESTful API for iLO will become the main management API for iLO and iLO Chassis Manager
-based HPE servers. Its feature set will become larger than the existing iLO XML API (RIBCL) and IPMI
-interfaces. Using this API, you can take full inventory of the server, control power and reset, configure
-BIOS and iLO settings, fetch event logs, as well as many other functions.
+This HPE RESTful API for iLO will become the main management API for iLO and
+iLO Chassis Manager based HPE servers. Its feature set will become larger than
+the existing iLO XML API (RIBCL) and IPMI interfaces. Using this API, you can
+take full inventory of the server, control power and reset, configure BIOS and
+iLO settings, fetch event logs, as well as many other functions.
 
-This API follows the trend of the Internet in moving to a common pattern for new software interfaces.
-Many web services in a variety of industries use REST APIs because they are easy to implement,
-easy to consume, and offer scalability advantages over previous technologies. HPE OneView,
-OpenStack, and many other server management APIs are now REST APIs. Most HPE Management
-software offerings, as well as the entire Software Defined Data Center architecture, are built upon
-REST APIs.
+This API follows the trend of the Internet in moving to a common pattern for
+new software interfaces. Many web services in a variety of industries use REST
+APIs because they are easy to implement, easy to consume, and offer scalability
+advantages over previous technologies. HPE OneView, OpenStack, and many other
+server management APIs are now REST APIs. Most HPE Management software
+offerings, as well as the entire Software Defined Data Center architecture, are
+built upon REST APIs.
 
-The HPE RESTful API for iLO has the additional advantage of consistency across all present and
-projected server architectures. The same data model works for traditional rack-mount servers,
-blades, as well as newer types of systems like Moonshot. This advantage comes because the data
-model is designed to self-describe the service’s capabilities to the client and has room for flexibility
-designed in from the start.
+The HPE RESTful API for iLO has the additional advantage of consistency across
+all present and projected server architectures. The same data model works for
+traditional rack-mount servers, blades, as well as newer types of systems like
+Moonshot. This advantage comes because the data model is designed to
+self-describe the service’s capabilities to the client and has room for
+flexibility designed in from the start.
 
 Resource operations
 -------------------
 
-RESTful APIs are stateless. The resource manager maintains the resource state that is reported as
-the resource representation. The client maintains the application state and the client might manipulate
-the resource locally, but until a PATCH or POST is made, the resource, as known by the resource
-manager, is not changed.
+RESTful APIs are stateless. The resource manager maintains the resource state
+that is reported as the resource representation. The client maintains the
+application state and the client might manipulate the resource locally, but
+until a PATCH or POST is made, the resource, as known by the resource manager,
+is not changed.
 
 +------------------------+---------------------------------+-----------------------------------------------------------+
 | Operation              | HTTP Verb                       | Description                                               |

--- a/docs/Quick-Start-Local.rest
+++ b/docs/Quick-Start-Local.rest
@@ -15,10 +15,18 @@ Local machine iLO restful operation
 
 Requirements
 -----------------------
-* You must be running on a server with iLO and the latest iLO drivers from the SPP.
-* You will need the download the iLOrest Chif DLL/SO for your corresponding operating system: `windows <https://downloads.hpe.com/pub/softlib2/software1/pubsw-windows/p1463761240/v120479/hprest_chif.dll>`_ / `linux <https://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1093353304/v120481/hprest_chif.so>`_.
+* You must be running on a server with iLO and the latest iLO drivers from the
+  SPP.
+* You will need the download the iLOrest Chif DLL/SO for your corresponding
+  operating system: `windows
+  <https://downloads.hpe.com/pub/softlib2/software1/pubsw-windows/p1463761240/v120479/hprest_chif.dll>`_
+  / `linux
+  <https://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1093353304/v120481/hprest_chif.so>`_.
 
-Restful operation on local HPE server uses the HpBlob interface. Instead of HTTP, blobstore is used for the transportation. The HPE python iLO Restful libarary provides support for both remote (HTTP) and in-band (blobstore) iLO Restful communication using HTTP and blobstore respectively.
+Restful operation on local HPE server uses the HpBlob interface. Instead of
+HTTP, blobstore is used for the transportation. The HPE python iLO Restful
+libarary provides support for both remote (HTTP) and in-band (blobstore) iLO
+Restful communication using HTTP and blobstore respectively.
 
 Make sure that redfish library is imported.
 
@@ -26,12 +34,19 @@ Make sure that redfish library is imported.
 
  import redfish
 
-Creation of local rest/redfish objects are same as remote rest/redfish object creation with the exception of the local hostname been **'blobstore://.'**. Once the object is created with proper hostname, the iLO Restful API provides the built-in support of performing RESTful requests on local machine iLO.
+Creation of local rest/redfish objects are same as remote rest/redfish object
+creation with the exception of the local hostname been **'blobstore://.'**.
+Once the object is created with proper hostname, the iLO Restful API provides
+the built-in support of performing RESTful requests on local machine iLO.
 
 Create a Redfish Object
 -----------------------
 
-A Redfish Rest object instance  is created by calling the  **redfish_client** method of the imported **redfish** library. The **redfish_client** method returns an instance of the Redfish RESTful client and takes as parameters iLO hostname/ ip address('**blobstore://.**'), user name, password, default rest prefix ('**/redfish/v1**') and other optional arguments.
+A Redfish Rest object instance is created by calling the **redfish_client**
+method of the imported **redfish** library. The **redfish_client** method
+returns an instance of the Redfish RESTful client and takes as parameters iLO
+hostname/ ip address('**blobstore://.**'), user name, password, default rest
+prefix ('**/redfish/v1**') and other optional arguments.
 
 .. code-block:: python
 
@@ -41,7 +56,11 @@ A Redfish Rest object instance  is created by calling the  **redfish_client** me
 Create a Rest Object
 ---------------------
 
-A Rest object instance is created by calling the **rest_client** method of the imported **redfish** library. The **rest_client** method returns an instance of the RESTful client and takes as parameters iLO hostname/ ip address('**blobstore://.**'), user name, password, default rest prefix ('**/rest/v1**') and other optional arguments.
+A Rest object instance is created by calling the **rest_client** method of the
+imported **redfish** library. The **rest_client** method returns an instance of
+the RESTful client and takes as parameters iLO hostname/ ip
+address('**blobstore://.**'), user name, password, default rest prefix
+('**/rest/v1**') and other optional arguments.
 
 .. code-block:: python
 
@@ -51,28 +70,41 @@ A Rest object instance is created by calling the **rest_client** method of the i
 Create a login session
 ----------------------
 
-Next the rest object's **login** method is called to initiate a rest session. The parameters for the login method are iLO user name, password and login type (default is Basic authentication). For "session" login, a session key is generated through a rest request.
+Next the rest object's **login** method is called to initiate a rest session.
+The parameters for the login method are iLO user name, password and login type
+(default is Basic authentication). For "session" login, a session key is
+generated through a rest request.
 
 .. code-block:: python
 
  REST_OBJ.login(auth="session")
 
-Please remember to call  **logout** method once the session is completed.
+Please remember to call **logout** method once the session is completed.
 
 Perform first Restful API operation
 -----------------------------------
 
-This is a very simple request example that shows the basic libraries involved and how to properly form the request. The following example performs a GET operation on the systems resource (/rest/v1/systems/1) using the HPE Restful API for iLO. It does a blobstore GET request on the iLO and returns a HTTP style response.
+This is a very simple request example that shows the basic libraries involved
+and how to properly form the request. The following example performs a GET
+operation on the systems resource (/rest/v1/systems/1) using the HPE Restful
+API for iLO. It does a blobstore GET request on the iLO and returns a HTTP
+style response.
 
-After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session.
+After creating a Redfish/Rest object as mentioned above in `Create a Rest
+Object`_ section followed by a login session.
 
-Next the Rest object's **get** method is called with the system uri (/rest/v1/systems/1) as the parameter. For this simple GET example no additional parameter is required but the Rest object's **put** and **post** method may take request header and body as parameters while **patch** method can take request body as parameter.
+Next the Rest object's **get** method is called with the system uri
+(/rest/v1/systems/1) as the parameter. For this simple GET example no
+additional parameter is required but the Rest object's **put** and **post**
+method may take request header and body as parameters while **patch** method
+can take request body as parameter.
 
 .. code-block:: python
 
  response = REST_OBJ.get('/rest/v1/systems/1')
 
-Print the HTTP GET response, the response includes response status, response header and response body.
+Print the HTTP GET response, the response includes response status, response
+header and response body.
 
 .. code-block:: python
 
@@ -90,4 +122,5 @@ Logout of the current session.
 Additional Examples
 -------------------
 
-Please look into the `examples <Examples.html>`_ section for more details on how to perform certain iLO tasks through RESTful requests using scripts.
+Please look into the `examples <Examples.html>`_ section for more details on
+how to perform certain iLO tasks through RESTful requests using scripts.

--- a/docs/Quick-Start-Local.rest
+++ b/docs/Quick-Start-Local.rest
@@ -1,8 +1,5 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-   
-   
 
 |
 
@@ -13,7 +10,6 @@
 Quick Start Local
 =================
 
-
 Local machine iLO restful operation
 ===================================
 
@@ -23,14 +19,12 @@ Requirements
 * You will need the download the iLOrest Chif DLL/SO for your corresponding operating system: `windows <https://downloads.hpe.com/pub/softlib2/software1/pubsw-windows/p1463761240/v120479/hprest_chif.dll>`_ / `linux <https://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1093353304/v120481/hprest_chif.so>`_.
 
 Restful operation on local HPE server uses the HpBlob interface. Instead of HTTP, blobstore is used for the transportation. The HPE python iLO Restful libarary provides support for both remote (HTTP) and in-band (blobstore) iLO Restful communication using HTTP and blobstore respectively.
- 
+
 Make sure that redfish library is imported.
 
 .. code-block:: python
 
-  import redfish
-
-::
+ import redfish
 
 Creation of local rest/redfish objects are same as remote rest/redfish object creation with the exception of the local hostname been **'blobstore://.'**. Once the object is created with proper hostname, the iLO Restful API provides the built-in support of performing RESTful requests on local machine iLO.
 
@@ -39,16 +33,10 @@ Create a Redfish Object
 
 A Redfish Rest object instance  is created by calling the  **redfish_client** method of the imported **redfish** library. The **redfish_client** method returns an instance of the Redfish RESTful client and takes as parameters iLO hostname/ ip address('**blobstore://.**'), user name, password, default rest prefix ('**/redfish/v1**') and other optional arguments.
 
-
 .. code-block:: python
 
-   REST_OBJ = redfish.redfish_client(base_url=host,username=login_account, 
+ REST_OBJ = redfish.redfish_client(base_url=host,username=login_account,
                                    password=login_password, default_prefix='/redfish/v1')
-::
-
- 
-
-
 
 Create a Rest Object
 ---------------------
@@ -57,11 +45,8 @@ A Rest object instance is created by calling the **rest_client** method of the i
 
 .. code-block:: python
 
-   REST_OBJ = redfish.rest_client(base_url=host,username=login_account,
+ REST_OBJ = redfish.rest_client(base_url=host,username=login_account,
                                 password=login_password, default_prefix='/rest/v1')
-
-
-::
 
 Create a login session
 ----------------------
@@ -70,21 +55,16 @@ Next the rest object's **login** method is called to initiate a rest session. Th
 
 .. code-block:: python
 
-  REST_OBJ.login(auth="session")
-
-::
+ REST_OBJ.login(auth="session")
 
 Please remember to call  **logout** method once the session is completed.
-
-
 
 Perform first Restful API operation
 -----------------------------------
 
 This is a very simple request example that shows the basic libraries involved and how to properly form the request. The following example performs a GET operation on the systems resource (/rest/v1/systems/1) using the HPE Restful API for iLO. It does a blobstore GET request on the iLO and returns a HTTP style response.
 
-
-After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session. 
+After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session.
 
 Next the Rest object's **get** method is called with the system uri (/rest/v1/systems/1) as the parameter. For this simple GET example no additional parameter is required but the Rest object's **put** and **post** method may take request header and body as parameters while **patch** method can take request body as parameter.
 
@@ -92,17 +72,11 @@ Next the Rest object's **get** method is called with the system uri (/rest/v1/sy
 
  response = REST_OBJ.get('/rest/v1/systems/1')
 
-::
-
 Print the HTTP GET response, the response includes response status, response header and response body.
 
 .. code-block:: python
 
  sys.stdout.write("%s\n" % response)
-
-::
-
-
 
 Close the login session
 -----------------------
@@ -112,11 +86,6 @@ Logout of the current session.
 .. code-block:: python
 
   REST_OBJ.logout()
-
-::
- 
-
-
 
 Additional Examples
 -------------------

--- a/docs/Quick-Start.rest
+++ b/docs/Quick-Start.rest
@@ -10,7 +10,14 @@
 Quick Start
 ===========
 
-This is a basic detailed breakdown of `quickstart.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/quickstart.py>`_ examples. This will cover object creation and a simple call to the API. For more elaborate example that use the API and Python library look at the examples in `RestfulApiExamples.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RestfulApiExamples.py>`_ and `RedfishApiExamples.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RedfishApiExamples.py>`_.
+This is a basic detailed breakdown of `quickstart.py
+<https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/quickstart.py>`_
+examples. This will cover object creation and a simple call to the API. For
+more elaborate example that use the API and Python library look at the examples
+in `RestfulApiExamples.py
+<https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RestfulApiExamples.py>`_
+and `RedfishApiExamples.py
+<https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RedfishApiExamples.py>`_.
 
 Make sure that redfish library is imported.
 
@@ -18,12 +25,17 @@ Make sure that redfish library is imported.
 
  import redfish
 
-The very first thing that needs to be done for a restful request is to create a rest object.
+The very first thing that needs to be done for a restful request is to create a
+rest object.
 
 Create a Redfish Object
 =======================
 
-A Redfish Rest object instance  is created by calling the  **redfish_client** method of the imported **redfish** library. The **redfish_client** method returns an instance of the Redfish RESTful client and takes as parameters iLO hostname/ ip address, user name, password, default rest prefix ('**/redfish/v1**') and other optional arguments.
+A Redfish Rest object instance is created by calling the **redfish_client**
+method of the imported **redfish** library. The **redfish_client** method
+returns an instance of the Redfish RESTful client and takes as parameters iLO
+hostname/ ip address, user name, password, default rest prefix
+('**/redfish/v1**') and other optional arguments.
 
 
 .. code-block:: python
@@ -34,7 +46,10 @@ A Redfish Rest object instance  is created by calling the  **redfish_client** me
 Create a Rest Object
 ====================
 
-A Rest object instance is created by calling the **rest_client** method of the imported **redfish** library. The **rest_client** method returns an instance of the RESTful client and takes as parameters iLO hostname/ ip address, user name, password, default rest prefix ('**/rest/v1**') and other optional arguments.
+A Rest object instance is created by calling the **rest_client** method of the
+imported **redfish** library. The **rest_client** method returns an instance of
+the RESTful client and takes as parameters iLO hostname/ ip address, user name,
+password, default rest prefix ('**/rest/v1**') and other optional arguments.
 
 .. code-block:: python
 
@@ -44,28 +59,42 @@ A Rest object instance is created by calling the **rest_client** method of the i
 Create a login session
 ======================
 
-Next the rest object's **login** method is called to initiate a rest session. The parameters for the login method are iLO user name, password and login type (default is Basic authentication). For "session" login, a session key is generated through a rest request.
+Next the rest object's **login** method is called to initiate a rest session.
+The parameters for the login method are iLO user name, password and login type
+(default is Basic authentication). For "session" login, a session key is
+generated through a rest request.
 
 .. code-block:: python
 
  REST_OBJ.login(auth="session")
 
-Please remember to call  **logout** method once the session is completed.
+Please remember to call **logout** method once the session is completed.
 
 Perform first Restful API operation
 ===================================
 
-This is a very simple request example that shows the basic libraries involved and how to properly form the request. The following example performs a GET operation on the systems resource (/rest/v1/systems/1) using the HP Restful API for iLO. It does an HTTP GET request on the iLO SSL(HTTPS) port (typically 443 but the iLO can be configured to use another port as well). The interface is not available over open HTTP (port 80), so SSL handshake must be used.
+This is a very simple request example that shows the basic libraries involved
+and how to properly form the request. The following example performs a GET
+operation on the systems resource (/rest/v1/systems/1) using the HP Restful API
+for iLO. It does an HTTP GET request on the iLO SSL(HTTPS) port (typically 443
+but the iLO can be configured to use another port as well). The interface is
+not available over open HTTP (port 80), so SSL handshake must be used.
 
-After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session.
+After creating a Redfish/Rest object as mentioned above in `Create a Rest
+Object`_ section followed by a login session.
 
-Next the Rest object's **get** method is called with the system uri (/rest/v1/systems/1) as the parameter. For this simple GET example no additional parameter is required but the Rest object's **put** and **post** method may take request header and body as parameters while **patch** method can take request body as parameter.
+Next the Rest object's **get** method is called with the system uri
+(/rest/v1/systems/1) as the parameter. For this simple GET example no
+additional parameter is required but the Rest object's **put** and **post**
+method may take request header and body as parameters while **patch** method
+can take request body as parameter.
 
 .. code-block:: python
 
  response = REST_OBJ.get('/rest/v1/systems/1')
 
-Print the HTTP GET response, the response includes response status, response header and response body.
+Print the HTTP GET response, the response includes response status, response
+header and response body.
 
 .. code-block:: python
 
@@ -106,4 +135,5 @@ Logout of the current session.
 Additional Examples
 ===================
 
-Please look into the `examples <Examples.html>`_ section for more details on how to perform certain iLO tasks through RESTful requests using scripts.
+Please look into the `examples <Examples.html>`_ section for more details on
+how to perform certain iLO tasks through RESTful requests using scripts.

--- a/docs/Quick-Start.rest
+++ b/docs/Quick-Start.rest
@@ -1,7 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-   
+
 |
 
 .. toctree::
@@ -11,9 +10,6 @@
 Quick Start
 ===========
 
-
-
-
 This is a basic detailed breakdown of `quickstart.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/quickstart.py>`_ examples. This will cover object creation and a simple call to the API. For more elaborate example that use the API and Python library look at the examples in `RestfulApiExamples.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RestfulApiExamples.py>`_ and `RedfishApiExamples.py <https://github.com/HewlettPackard/python-ilorest-library/tree/master/examples/RedfishApiExamples.py>`_.
 
 Make sure that redfish library is imported.
@@ -21,8 +17,6 @@ Make sure that redfish library is imported.
 .. code-block:: python
 
  import redfish
-
-..
 
 The very first thing that needs to be done for a restful request is to create a rest object.
 
@@ -34,13 +28,8 @@ A Redfish Rest object instance  is created by calling the  **redfish_client** me
 
 .. code-block:: python
 
-   REST_OBJ = redfish.redfish_client(base_url=host,username=login_account, 
+ REST_OBJ = redfish.redfish_client(base_url=host,username=login_account,
                                    password=login_password, default_prefix='/redfish/v1')
-::
-
- 
-
-
 
 Create a Rest Object
 ====================
@@ -49,11 +38,8 @@ A Rest object instance is created by calling the **rest_client** method of the i
 
 .. code-block:: python
 
-   REST_OBJ = redfish.rest_client(base_url=host,username=login_account,
+ REST_OBJ = redfish.rest_client(base_url=host,username=login_account,
                                 password=login_password, default_prefix='/rest/v1')
-
-
-::
 
 Create a login session
 ======================
@@ -62,21 +48,16 @@ Next the rest object's **login** method is called to initiate a rest session. Th
 
 .. code-block:: python
 
-  REST_OBJ.login(auth="session")
-
-::
+ REST_OBJ.login(auth="session")
 
 Please remember to call  **logout** method once the session is completed.
-
-
 
 Perform first Restful API operation
 ===================================
 
 This is a very simple request example that shows the basic libraries involved and how to properly form the request. The following example performs a GET operation on the systems resource (/rest/v1/systems/1) using the HP Restful API for iLO. It does an HTTP GET request on the iLO SSL(HTTPS) port (typically 443 but the iLO can be configured to use another port as well). The interface is not available over open HTTP (port 80), so SSL handshake must be used.
 
-
-After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session. 
+After creating a Redfish/Rest object as mentioned above in `Create a Rest Object`_ section followed by a login session.
 
 Next the Rest object's **get** method is called with the system uri (/rest/v1/systems/1) as the parameter. For this simple GET example no additional parameter is required but the Rest object's **put** and **post** method may take request header and body as parameters while **patch** method can take request body as parameter.
 
@@ -84,24 +65,17 @@ Next the Rest object's **get** method is called with the system uri (/rest/v1/sy
 
  response = REST_OBJ.get('/rest/v1/systems/1')
 
-::
-
 Print the HTTP GET response, the response includes response status, response header and response body.
 
 .. code-block:: python
 
  sys.stdout.write("%s\n" % response)
 
-::
-
 Response status:
 
  200
 
-
 Response header:
-
-
 
  | content-length 4135
  | server HPE-iLO-Server/1.30
@@ -115,15 +89,10 @@ Response header:
  | x_hp-chrp-service-version 1.0.3
  | content-type application/json; charset=utf-8
 
-
 Response body (formatted using Postman):
 
- 
 .. image:: /images/iLO_sys1.jpg
    :height: 200
-   
- 
-
 
 Close the login session
 -----------------------
@@ -132,12 +101,7 @@ Logout of the current session.
 
 .. code-block:: python
 
-  REST_OBJ.logout()
-
-::
- 
-
-
+ REST_OBJ.logout()
 
 Additional Examples
 ===================

--- a/docs/ex10_add_ilo_user_account.rest
+++ b/docs/ex10_add_ilo_user_account.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,47 +11,35 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 10: Add iLO user account
-===============================
+================================
 
 The method **ex10_add_ilo_user_account** takes an instance of rest object , new iLO login name, new iLO user name, new iLO password, remote console privilege, iLO configuration privilege, virtual media privilege, user configuration privilege and virtual power and reset privilege.
 
 .. code-block:: python
 
-  def ex10_add_ilo_user_account(redfishobj, new_ilo_loginname, new_ilo_username, \
-                                 new_ilo_password, irc=None, cfg=None, \
-                                 virtual_media=None, usercfg=None, vpr=None):
-
-::
+ def ex10_add_ilo_user_account(redfishobj, new_ilo_loginname, new_ilo_username, \
+                               new_ilo_password, irc=None, cfg=None, \
+                               virtual_media=None, usercfg=None, vpr=None):
 
 Find and get the system resource for account service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("AccountService.")
-
-::
+ instances = restobj.search_for_type("AccountService.")
 
 Send a HTTP GET request to the  account service URI(s).
 
 .. code-block:: python
 
  for instance in instances:
-        rsp = restobj.rest_get(instance["href"])
-
-::
+     rsp = restobj.rest_get(instance["href"])
 
 Prepare the request body for new  user account. iLO has two user account properties, Login name is the string used as the user identity to log in, we use this for 'UserName'. User name is the friendly (or full) name of the user, potentially easy to reverse. Use the iLO account login name as 'UserName' in the API.
 
@@ -61,32 +47,21 @@ Prepare the request body for new  user account. iLO has two user account propert
 
  body = {"UserName": new_ilo_loginname, "Password": new_ilo_password, "Oem": {}}
 
-::
-
 Set up rest of the request body with the requested privileges to the  new user, by default only the login privilege is enabled..
 
 .. code-block:: python
 
-        body["Oem"]["Hp"] = {}
-        body["Oem"]["Hp"]["LoginName"] = new_ilo_username
-        body["Oem"]["Hp"]["Privileges"] = {}
-        body["Oem"]["Hp"]["Privileges"]["RemoteConsolePriv"] = irc
-        body["Oem"]["Hp"]["Privileges"]["iLOConfigPriv"] = cfg
-        body["Oem"]["Hp"]["Privileges"]["VirtualMediaPriv"] = virtual_media
-        body["Oem"]["Hp"]["Privileges"]["UserConfigPriv"] = usercfg
-        body["Oem"]["Hp"]["Privileges"]["VirtualPowerAndResetPriv"] = vpr
-::
-
+ body["Oem"]["Hp"] = {}
+ body["Oem"]["Hp"]["LoginName"] = new_ilo_username
+ body["Oem"]["Hp"]["Privileges"] = {}
+ body["Oem"]["Hp"]["Privileges"]["RemoteConsolePriv"] = irc
+ body["Oem"]["Hp"]["Privileges"]["iLOConfigPriv"] = cfg
+ body["Oem"]["Hp"]["Privileges"]["VirtualMediaPriv"] = virtual_media
+ body["Oem"]["Hp"]["Privileges"]["UserConfigPriv"] = usercfg
+ body["Oem"]["Hp"]["Privileges"]["VirtualPowerAndResetPriv"] = vpr
 
 Create the account through a POST request.
 
 .. code-block:: python
 
-    newrsp = restobj.rest_post(rsp.dict["links"]["Accounts"]["href"], body)
-
-::
-
-
-   
-
-  
+ newrsp = restobj.rest_post(rsp.dict["links"]["Accounts"]["href"], body)

--- a/docs/ex10_add_ilo_user_account.rest
+++ b/docs/ex10_add_ilo_user_account.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,10 @@ Redfish Object creation:
 Example 10: Add iLO user account
 ================================
 
-The method **ex10_add_ilo_user_account** takes an instance of rest object , new iLO login name, new iLO user name, new iLO password, remote console privilege, iLO configuration privilege, virtual media privilege, user configuration privilege and virtual power and reset privilege.
+The method **ex10_add_ilo_user_account** takes an instance of rest object, new
+iLO login name, new iLO user name, new iLO password, remote console privilege,
+iLO configuration privilege, virtual media privilege, user configuration
+privilege and virtual power and reset privilege.
 
 .. code-block:: python
 
@@ -41,13 +48,18 @@ Send a HTTP GET request to the  account service URI(s).
  for instance in instances:
      rsp = restobj.rest_get(instance["href"])
 
-Prepare the request body for new  user account. iLO has two user account properties, Login name is the string used as the user identity to log in, we use this for 'UserName'. User name is the friendly (or full) name of the user, potentially easy to reverse. Use the iLO account login name as 'UserName' in the API.
+Prepare the request body for new  user account. iLO has two user account
+properties, Login name is the string used as the user identity to log in, we
+use this for 'UserName'. User name is the friendly (or full) name of the user,
+potentially easy to reverse. Use the iLO account login name as 'UserName' in
+the API.
 
 .. code-block:: python
 
  body = {"UserName": new_ilo_loginname, "Password": new_ilo_password, "Oem": {}}
 
-Set up rest of the request body with the requested privileges to the  new user, by default only the login privilege is enabled..
+Set up rest of the request body with the requested privileges to the  new user,
+by default only the login privilege is enabled.
 
 .. code-block:: python
 

--- a/docs/ex11_modify_ilo_user_account.rest
+++ b/docs/ex11_modify_ilo_user_account.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,48 +11,35 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 11: Modify iLO user account
-==================================
+===================================
 
 The method **ex11_modify_ilo_user_account** takes an instance of rest object , iLO login account name to modify, new iLO login name, new user name, new password, remote console privilege, iLO configuration privilege, virtual media privilege, user configuration privilege and virtual power and reset privilege.
 
 .. code-block:: python
 
-  def ex11_modify_ilo_user_account(restobj, ilo_login_name_to_modify, \
+ def ex11_modify_ilo_user_account(restobj, ilo_login_name_to_modify, \
                 new_ilo_loginname, new_ilo_username, new_ilo_password, \
                 irc=None, cfg=None, virtual_media=None, usercfg=None, vpr=None):
-
-::
 
 Find and get the system resource for account service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("AccountService.")
-
-::
-
+ instances = restobj.search_for_type("AccountService.")
 
 Send  HTTP GET request to the  account service URI(s).
 
 .. code-block:: python
 
  for instance in instances:
-        rsp = restobj.rest_get(instance["href"])
-
-::
+     rsp = restobj.rest_get(instance["href"])
 
 Send another GET request to get  accounts resources.
 
@@ -61,61 +47,52 @@ Send another GET request to get  accounts resources.
 
  accounts = restobj.rest_get(response.dict["links"]["Accounts"]["href"])
 
-::
-
-
 For the requested account to modify, add the requested fields and value from the arguments passed.
 
 .. code-block:: python
 
-      for account in accounts.dict["Items"]:
-            if account["UserName"] == ilo_login_name_to_modify:
-                body = {}
-                body_oemhp = {}
-                body_oemhp_privs = {}
-    
-                # if new loginname or password specified
-                if new_ilo_password:
-                    body["Password"] = new_ilo_password
-                if new_ilo_loginname:
-                    body["UserName"] = new_ilo_loginname
-    
-                # if different username specified
-                if new_ilo_username:
-                    body_oemhp["LoginName"] = new_ilo_username
-    
-                # if different privileges were requested (None = no change)
-                if irc != None:
-                    body_oemhp_privs["RemoteConsolePriv"] = irc
-                if virtual_media != None:
-                    body_oemhp_privs["VirtualMediaPriv"] = virtual_media
-                if cfg != None:
-                    body_oemhp_privs["iLOConfigPriv"] = cfg
-                if usercfg != None:
-                    body_oemhp_privs["UserConfigPriv"] = usercfg
-                if vpr != None:
-                    body_oemhp_privs["VirtualPowerAndResetPriv"] = vpr
-    
-::
+ for account in accounts.dict["Items"]:
+     if account["UserName"] == ilo_login_name_to_modify:
+         body = {}
+         body_oemhp = {}
+         body_oemhp_privs = {}
+
+         # if new loginname or password specified
+         if new_ilo_password:
+             body["Password"] = new_ilo_password
+         if new_ilo_loginname:
+             body["UserName"] = new_ilo_loginname
+
+         # if different username specified
+         if new_ilo_username:
+             body_oemhp["LoginName"] = new_ilo_username
+
+         # if different privileges were requested (None = no change)
+         if irc != None:
+             body_oemhp_privs["RemoteConsolePriv"] = irc
+         if virtual_media != None:
+             body_oemhp_privs["VirtualMediaPriv"] = virtual_media
+         if cfg != None:
+             body_oemhp_privs["iLOConfigPriv"] = cfg
+         if usercfg != None:
+             body_oemhp_privs["UserConfigPriv"] = usercfg
+         if vpr != None:
+             body_oemhp_privs["VirtualPowerAndResetPriv"] = vpr
 
 Organize the PATCH request body.
 
 .. code-block:: python
 
-                if len(body_oemhp_privs):
-                    body_oemhp["Privileges"] = body_oemhp_privs
-                if len(body_oemhp):
-                    body["Oem"] = {"Hp": body_oemhp}
-
-::
+ if len(body_oemhp_privs):
+     body_oemhp["Privileges"] = body_oemhp_privs
+ if len(body_oemhp):
+     body["Oem"] = {"Hp": body_oemhp}
 
 Update the account through a PATCH request. Warning, if you don't change anything, you will
 get an HTTP 400 response back.
 
 .. code-block:: python
 
-           newrsp = restobj.rest_patch(account["links"]["self"]["href"], body)
-           restobj.error_handler(newrsp)
-
-::
+ newrsp = restobj.rest_patch(account["links"]["self"]["href"], body)
+ restobj.error_handler(newrsp)
 

--- a/docs/ex11_modify_ilo_user_account.rest
+++ b/docs/ex11_modify_ilo_user_account.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,10 @@ Redfish Object creation:
 Example 11: Modify iLO user account
 ===================================
 
-The method **ex11_modify_ilo_user_account** takes an instance of rest object , iLO login account name to modify, new iLO login name, new user name, new password, remote console privilege, iLO configuration privilege, virtual media privilege, user configuration privilege and virtual power and reset privilege.
+The method **ex11_modify_ilo_user_account** takes an instance of rest object,
+iLO login account name to modify, new iLO login name, new user name, new
+password, remote console privilege, iLO configuration privilege, virtual media
+privilege, user configuration privilege and virtual power and reset privilege.
 
 .. code-block:: python
 
@@ -47,7 +54,8 @@ Send another GET request to get  accounts resources.
 
  accounts = restobj.rest_get(response.dict["links"]["Accounts"]["href"])
 
-For the requested account to modify, add the requested fields and value from the arguments passed.
+For the requested account to modify, add the requested fields and value from
+the arguments passed.
 
 .. code-block:: python
 
@@ -88,8 +96,8 @@ Organize the PATCH request body.
  if len(body_oemhp):
      body["Oem"] = {"Hp": body_oemhp}
 
-Update the account through a PATCH request. Warning, if you don't change anything, you will
-get an HTTP 400 response back.
+Update the account through a PATCH request. Warning, if you don't change
+anything, you will get an HTTP 400 response back.
 
 .. code-block:: python
 

--- a/docs/ex12_remove_ilo_account.rest
+++ b/docs/ex12_remove_ilo_account.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 12: Remove iLO user account
 ===================================
 
-The method **ex12_remove_ilo_account** takes an instance of rest object ( or redfish object if using Redfish API ) and  iLO login name for the account to be removed.
+The method **ex12_remove_ilo_account** takes an instance of rest object (or
+redfish object if using Redfish API) and iLO login name for the account to be
+removed.
 
 .. code-block:: python
 
@@ -45,8 +51,11 @@ Send another GET request to get  accounts resources.
 
  accounts = restobj.rest_get(response.dict["links"]["Accounts"]["href"])
 
-For the requested account to be removed, send a DELETE request to the account uri.
-iLO has two user account properties, Login name is the string used as the user identity to log in, we use this for 'UserName'. User name is the friendly (or full) name of the user, potentially easy to reverse. Use the iLO account login name as 'UserName' in the API.
+For the requested account to be removed, send a DELETE request to the account
+uri. iLO has two user account properties, Login name is the string used as the
+user identity to log in, we use this for 'UserName'. User name is the friendly
+(or full) name of the user, potentially easy to reverse. Use the iLO account
+login name as 'UserName' in the API.
 
 .. code-block:: python
 

--- a/docs/ex12_remove_ilo_account.rest
+++ b/docs/ex12_remove_ilo_account.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,16 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
-
 
 Example 12: Remove iLO user account
 ===================================
@@ -30,27 +24,20 @@ The method **ex12_remove_ilo_account** takes an instance of rest object ( or red
 
 .. code-block:: python
 
-  def ex12_remove_ilo_account(restobj, ilo_loginname_to_remove):
-
-::
+ def ex12_remove_ilo_account(restobj, ilo_loginname_to_remove):
 
 Find and get the system resource for account service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("AccountService.")
-
-::
+ instances = restobj.search_for_type("AccountService.")
 
 Send  HTTP GET request to the  account service URI(s).
 
 .. code-block:: python
 
  for instance in instances:
-        rsp = restobj.rest_get(instance["href"])
-
-::
+     rsp = restobj.rest_get(instance["href"])
 
 Send another GET request to get  accounts resources.
 
@@ -58,16 +45,12 @@ Send another GET request to get  accounts resources.
 
  accounts = restobj.rest_get(response.dict["links"]["Accounts"]["href"])
 
-::
-
 For the requested account to be removed, send a DELETE request to the account uri.
 iLO has two user account properties, Login name is the string used as the user identity to log in, we use this for 'UserName'. User name is the friendly (or full) name of the user, potentially easy to reverse. Use the iLO account login name as 'UserName' in the API.
 
 .. code-block:: python
 
-     for account in accounts.dict["Items"]:
-            if account["UserName"] == ilo_loginname_to_remove:
-                newrsp = restobj.rest_delete(account["links"]["self"]["href"])
-                restobj.error_handler(newrsp)
-
-::
+ for account in accounts.dict["Items"]:
+     if account["UserName"] == ilo_loginname_to_remove:
+         newrsp = restobj.rest_delete(account["links"]["self"]["href"])
+         restobj.error_handler(newrsp)

--- a/docs/ex13_dump_ilo_nic.rest
+++ b/docs/ex13_dump_ilo_nic.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 13: Dump iLO NIC states
 ===============================
 
-The method **ex13_dump_ilo_nic** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex13_dump_ilo_nic** takes an instance of rest object (or redfish
+object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -38,7 +43,8 @@ Send a HTTP GET request to the  manager URI(s).
 
  rsp = restobj.rest_get(instance["href"])
 
-Send another GET request using the ethernet interface URI(s) from the respose body.
+Send another GET request using the ethernet interface URI(s) from the respose
+body.
 
 .. code-block:: python
   

--- a/docs/ex13_dump_ilo_nic.rest
+++ b/docs/ex13_dump_ilo_nic.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 13: Dump iLO NIC states
 ===============================
@@ -30,69 +24,53 @@ The method **ex13_dump_ilo_nic** takes an instance of rest object ( or redfish o
 
 .. code-block:: python
 
-  def ex13_dump_ilo_nic(restobj)
+ def ex13_dump_ilo_nic(restobj)
 
-::
-
-Find and get the system resource for manager. 
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Manager.")
-
-::
+ instances = restobj.search_for_type("Manager.")
 
 Send a HTTP GET request to the  manager URI(s).
 
 .. code-block:: python
 
-           rsp = restobj.rest_get(instance["href"])
-::
+ rsp = restobj.rest_get(instance["href"])
 
 Send another GET request using the ethernet interface URI(s) from the respose body.
 
 .. code-block:: python
-
   
-    response = restobj.rest_get(rsp.dict["links"]["EthernetNICs"]["href"])
-
-
-::
-
+ response = restobj.rest_get(rsp.dict["links"]["EthernetNICs"]["href"])
 
 Check the response body for NIC status states and print the states.
 
 .. code-block:: python
 
-            for nic in response.dict["Items"]:
-            if nic["Status"]["State"] == "Enabled":
-                sys.stdout.write("\t" + nic["Name"] + "\n")
+ for nic in response.dict["Items"]:
+      if nic["Status"]["State"] == "Enabled":
+          sys.stdout.write("\t" + nic["Name"] + "\n")
 
-                if "MacAddress" not in nic:
-                    sys.stderr.write("\tNo MacAddress information available (no"
-                           " 'MacAddress' property in NIC resource)\n")
-                else:
-                    sys.stdout.write("\tMAC: " + str(nic["MacAddress"]) + "\n")
-
-                sys.stdout.write("\tSpeed: " + str(nic["SpeedMbps"]) + "\n")
-                sys.stdout.write("\tAutosense:  " + \
-                                                str(nic["Autosense"]) + "\n")
-                sys.stdout.write("\tFull Duplex:  " + str(nic["FullDuplex"]) \
-                                                                        + "\n")
-                if "FQDN" not in nic:
-                    sys.stderr.write("\tNo FQDN information available\n")
-                else:
-                    sys.stdout.write("\tFQDN:  " + str(nic["FQDN"]) + "\n")
-                for addr in nic["IPv4Addresses"]:
-                    sys.stdout.write("\tIPv4 Address:  " + addr["Address"] 
-                           + " from " + addr["AddressOrigin"] + "\n")
-                if "IPv6Addresses" not in nic:
-                    sys.stderr.write("\tIPv6Addresses information not "\
-                                                                "available\n")
-                else:
-                    for addr in nic["IPv6Addresses"]:
-                        sys.stdout.write("\tIPv6 Address:  " + addr["Address"] 
+          if "MacAddress" not in nic:
+              sys.stderr.write("\tNo MacAddress information available (no"
+                               " 'MacAddress' property in NIC resource)\n")
+          else:
+              sys.stdout.write("\tMAC: " + str(nic["MacAddress"]) + "\n")
+              sys.stdout.write("\tSpeed: " + str(nic["SpeedMbps"]) + "\n")
+              sys.stdout.write("\tAutosense:  " + str(nic["Autosense"]) + "\n")
+              sys.stdout.write("\tFull Duplex:  " + str(nic["FullDuplex"]) + "\n")
+          if "FQDN" not in nic:
+              sys.stderr.write("\tNo FQDN information available\n")
+          else:
+              sys.stdout.write("\tFQDN:  " + str(nic["FQDN"]) + "\n")
+          for addr in nic["IPv4Addresses"]:
+              sys.stdout.write("\tIPv4 Address:  " + addr["Address"]
                                + " from " + addr["AddressOrigin"] + "\n")
-
-::
+          if "IPv6Addresses" not in nic:
+              sys.stderr.write("\tIPv6Addresses information not "\
+                               "available\n")
+          else:
+              for addr in nic["IPv6Addresses"]:
+                  sys.stdout.write("\tIPv6 Address:  " + addr["Address"]
+                                   + " from " + addr["AddressOrigin"] + "\n")

--- a/docs/ex14_sessions.rest
+++ b/docs/ex14_sessions.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 14: Create and delete a user session
 ============================================
 
-The method **ex14_sessions** takes an instance of rest object( or redfish object if using Redfish API ) , iLO login user name and iLO login password as arguments.
+The method **ex14_sessions** takes an instance of rest object (or redfish
+object if using Redfish API), iLO login user name and iLO login password as
+arguments.
 
 .. code-block:: python
 
@@ -32,14 +38,17 @@ Create a new session dictionary with iLO login username and login password.
  
  new_session = {"UserName": login_account, "Password": login_password}
 
-Sent a POST request to the URI '/rest/v1/Sessions' with the created session dictionary as request body to create a session.
+Sent a POST request to the URI '/rest/v1/Sessions' with the created session
+dictionary as request body to create a session.
 
 .. code-block:: python
 
  response = restobj.rest_post("/rest/v1/Sessions", new_session)
  restobj.error_handler(response)
 
-For a successful response status get the session URI, session key from the response header. ILO returns lower case header names though HTTP headers are case insensitive.
+For a successful response status get the session URI, session key from the
+response header. ILO returns lower case header names though HTTP headers are
+case insensitive.
 
 .. code-block:: python
 
@@ -51,7 +60,8 @@ For a successful response status get the session URI, session key from the respo
      x_auth_token = response.getheader("x-auth-token")
      sys.stdout.write("\tSession key " + x_auth_token + " created\n")
 
-Send  DELETE request to the session URI in order to log out of the session and check the response status.
+Send  DELETE request to the session URI in order to log out of the session and
+check the response status.
 
 .. code-block:: python
 

--- a/docs/ex14_sessions.rest
+++ b/docs/ex14_sessions.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,66 +11,49 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 14: Create and delete a user session
-==============================================
+============================================
 
 The method **ex14_sessions** takes an instance of rest object( or redfish object if using Redfish API ) , iLO login user name and iLO login password as arguments.
 
 .. code-block:: python
 
-  def ex14_sessions(restobj, login_account, login_password):
-
-::
+ def ex14_sessions(restobj, login_account, login_password):
 
 Create a new session dictionary with iLO login username and login password.
 
 .. code-block:: python
  
-  new_session = {"UserName": login_account, "Password": login_password}
-
-::
+ new_session = {"UserName": login_account, "Password": login_password}
 
 Sent a POST request to the URI '/rest/v1/Sessions' with the created session dictionary as request body to create a session.
 
 .. code-block:: python
 
-  response = restobj.rest_post("/rest/v1/Sessions", new_session)
-  restobj.error_handler(response)
-  
-::
+ response = restobj.rest_post("/rest/v1/Sessions", new_session)
+ restobj.error_handler(response)
 
 For a successful response status get the session URI, session key from the response header. ILO returns lower case header names though HTTP headers are case insensitive.
 
 .. code-block:: python
 
-    if response.status == 201:
-        session_uri = response.getheader("location")
-        session_uri = urlparse.urlparse(session_uri)
-        sys.stdout.write("\tSession " + session_uri.path + " created\n")
+ if response.status == 201:
+     session_uri = response.getheader("location")
+     session_uri = urlparse.urlparse(session_uri)
+     sys.stdout.write("\tSession " + session_uri.path + " created\n")
 
-        x_auth_token = response.getheader("x-auth-token")
-        sys.stdout.write("\tSession key " + x_auth_token + " created\n")
-
-::
-
-
+     x_auth_token = response.getheader("x-auth-token")
+     sys.stdout.write("\tSession key " + x_auth_token + " created\n")
 
 Send  DELETE request to the session URI in order to log out of the session and check the response status.
 
 .. code-block:: python
 
-    sessresp = restobj.rest_delete(session_uri.path)
-    restobj.error_handler(sessresp)
-
-::
+ sessresp = restobj.rest_delete(session_uri.path)
+ restobj.error_handler(sessresp)

--- a/docs/ex15_set_uid_light.rest
+++ b/docs/ex15_set_uid_light.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,64 +11,41 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
-
 Example 15: Set UID light
 =========================
 
 The method **ex15_set_uid_light** takes an instance of rest object (or redfish object if using Redfish API) and  boolean uid state (FALSE for turn off  or TRUE for turn on) as arguments.
 
+.. code-block:: python
+
+ def ex15_set_uid_light(restobj, uid):
+
+Find and get the system resource for computer system.
 
 .. code-block:: python
 
-
-    def ex15_set_uid_light(restobj, uid):
-
-::
-
-
-Find and get the system resource for computer system. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("ComputerSystem.")
-
-::
-
-
+ instances = restobj.search_for_type("ComputerSystem.")
 
 Prepare the PATCH request header based on the requested UID state parameter.
 
 .. code-block:: python
 
-        for instance in instances:
-           body = dict()
-           if uid:
-             body["IndicatorLED"] = "Lit"
-           else:
-             body["IndicatorLED"] = "Off"
-
-
-::
+ for instance in instances:
+     body = dict()
+     if uid:
+         body["IndicatorLED"] = "Lit"
+     else:
+         body["IndicatorLED"] = "Off"
 
 Perform the PATCH action, check the response.
 
 .. code-block:: python
 
-        response = restobj.rest_patch(instance["href"], body)
-        restobj.error_handler(response)
-
-::
- 
- 
+ response = restobj.rest_patch(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex15_set_uid_light.rest
+++ b/docs/ex15_set_uid_light.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 15: Set UID light
 =========================
 
-The method **ex15_set_uid_light** takes an instance of rest object (or redfish object if using Redfish API) and  boolean uid state (FALSE for turn off  or TRUE for turn on) as arguments.
+The method **ex15_set_uid_light** takes an instance of rest object (or redfish
+object if using Redfish API) and boolean uid state (FALSE for turn off  or
+TRUE for turn on) as arguments.
 
 .. code-block:: python
 

--- a/docs/ex16_computer_details.rest
+++ b/docs/ex16_computer_details.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,138 +11,113 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 16: Get computer details
 ================================
 
 The method **ex16_computer_details** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ def ex16_computer_details(restobj):
+
+Find and get the system resource for computer system.
 
 .. code-block:: python
 
-
-    def ex16_computer_details(restobj):
-
-::
-
-
-Find and get the system resource for computer system. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("ComputerSystem.")
-
-::
+ instances = restobj.search_for_type("ComputerSystem.")
 
 Send HTTP GET request to the  system URI(s).
 
 .. code-block:: python
 
-  for instance in instances:
-      response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 For each system print manufacturer, model and serial number from the response body..
 
 .. code-block:: python
 
-        sys.stdout.write("\tManufacturer:  " + \
-                                str(response.dict["Manufacturer"]) + "\n")
-        sys.stdout.write("\tModel:  " + str(response.dict["Model"]) + "\n")
-        sys.stdout.write("\tSerial Number:  " + \
-                                str(response.dict["SerialNumber"]) + "\n")
-::
+ sys.stdout.write("\tManufacturer:  " + \
+                  str(response.dict["Manufacturer"]) + "\n")
+ sys.stdout.write("\tModel:  " + str(response.dict["Model"]) + "\n")
+ sys.stdout.write("\tSerial Number:  " + \
+                  str(response.dict["SerialNumber"]) + "\n")
 
 Next print virtual serial number, virtual UUID, asset tag if any.
 
 .. code-block:: python
 
-        if "VirtualSerialNumber" in response.dict:
-            sys.stdout.write("\tVirtual Serial Number:  " +
-                   str(response.dict["VirtualSerialNumber"]) + "\n")
-        else:
-            sys.stderr.write("\tVirtual Serial Number information not " \
-                                        "available on system resource\n")
-            sys.stdout.write("\tUUID:  " + str(response.dict["UUID"]) + "\n")
+ if "VirtualSerialNumber" in response.dict:
+     sys.stdout.write("\tVirtual Serial Number:  " +
+                      str(response.dict["VirtualSerialNumber"]) + "\n")
+ else:
+     sys.stderr.write("\tVirtual Serial Number information not " \
+                      "available on system resource\n")
+     sys.stdout.write("\tUUID:  " + str(response.dict["UUID"]) + "\n")
 
-        if "VirtualUUID" in response.dict["Oem"]["Hp"]:
-            sys.stdout.write("\tVirtualUUID:  " + \
-                     str(response.dict["Oem"]["Hp"]["VirtualUUID"]) + "\n")
-        else:
-            sys.stderr.write("\tVirtualUUID not available system " \
-                                                            "resource\n")
-        if "AssetTag" in response.dict:
-            sys.stdout.write("\tAsset Tag:  " + response.dict["AssetTag"] \
-                                                                    + "\n")
-        else:
-            sys.stderr.write("\tNo Asset Tag information on system"  \
-                                                             "resource\n")
-
-::
+ if "VirtualUUID" in response.dict["Oem"]["Hp"]:
+     sys.stdout.write("\tVirtualUUID:  " + \
+                      str(response.dict["Oem"]["Hp"]["VirtualUUID"]) + "\n")
+ else:
+     sys.stderr.write("\tVirtualUUID not available system " \
+                      "resource\n")
+ if "AssetTag" in response.dict:
+     sys.stdout.write("\tAsset Tag:  " + response.dict["AssetTag"] \
+                      + "\n")
+ else:
+     sys.stderr.write("\tNo Asset Tag information on system"  \
+                      "resource\n")
 
 Print BIOS version, memory and CPU information.
 
 .. code-block:: python
 
-        sys.stdout.write("\tBIOS Version: " + \
-                 response.dict["Bios"]["Current"]["VersionString"] + "\n")
+ sys.stdout.write("\tBIOS Version: " + \
+                  response.dict["Bios"]["Current"]["VersionString"] + "\n")
 
-        sys.stdout.write("\tMemory:  " + 
-               str(response.dict["Memory"]["TotalSystemMemoryGB"]) +" GB\n")
+ sys.stdout.write("\tMemory:  " +
+                  str(response.dict["Memory"]["TotalSystemMemoryGB"]) +" GB\n")
 
-        sys.stdout.write("\tProcessors:  " + \
-                 str(response.dict["Processors"]["Count"]) + " x " + \
-                 str(response.dict["Processors"]["ProcessorFamily"])+ "\n")
-
-::
+ sys.stdout.write("\tProcessors:  " + \
+                  str(response.dict["Processors"]["Count"]) + " x " + \
+                  str(response.dict["Processors"]["ProcessorFamily"])+ "\n")
 
 Print health information.
 
 .. code-block:: python
 
-  if "Status" not in response.dict or "Health" not in \
-                                                    response.dict["Status"]:
-            sys.stdout.write("\tStatus/Health information not available in "
-                                                        "system resource\n")
-  else:
-            sys.stdout.write("\tHealth:  " + \
-                             str(response.dict["Status"]["Health"]) + "\n")
-
-::
+ if "Status" not in response.dict or "Health" not in response.dict["Status"]:
+     sys.stdout.write("\tStatus/Health information not available in "
+                      "system resource\n")
+ else:
+     sys.stdout.write("\tHealth:  " + \
+                      str(response.dict["Status"]["Health"]) + "\n")
 
 If host correlation available, print details.
 
 .. code-block:: python
 
-       if "HostCorrelation" in response.dict:
-            if "HostFQDN" in response.dict["HostCorrelation"]:
-                sys.stdout.write("\tHost FQDN:  " + \
-                     response.dict["HostCorrelation"]["HostFQDN"] + "\n")
-                
-            if "HostMACAddress" in response.dict["HostCorrelation"]:
-                for mac in response.dict["HostCorrelation"]["HostMACAddress"]:
-                    sys.stdout.write("\tHost MAC Address:  " + str(mac) + "\n")
+ if "HostCorrelation" in response.dict:
+     if "HostFQDN" in response.dict["HostCorrelation"]:
+         sys.stdout.write("\tHost FQDN:  " + \
+                          response.dict["HostCorrelation"]["HostFQDN"] + "\n")
 
-            if "HostName" in response.dict["HostCorrelation"]:
-                sys.stdout.write("\tHost Name:  " + \
-                     response.dict["HostCorrelation"]["HostName"] + "\n")
+     if "HostMACAddress" in response.dict["HostCorrelation"]:
+         for mac in response.dict["HostCorrelation"]["HostMACAddress"]:
+             sys.stdout.write("\tHost MAC Address:  " + str(mac) + "\n")
 
-            if "IPAddress" in response.dict["HostCorrelation"]:
-                for ip_address in response.dict["HostCorrelation"]\
-                                                            ["IPAddress"]:
-                    if ip_address:
-                        sys.stdout.write("\tHost IP Address:  " + \
-                                                    str(ip_address) + "\n")
-::
+     if "HostName" in response.dict["HostCorrelation"]:
+         sys.stdout.write("\tHost Name:  " + \
+                          response.dict["HostCorrelation"]["HostName"] + "\n")
+
+     if "IPAddress" in response.dict["HostCorrelation"]:
+         for ip_address in response.dict["HostCorrelation"]["IPAddress"]:
+             if ip_address:
+                 sys.stdout.write("\tHost IP Address:  " + \
+                                  str(ip_address) + "\n")

--- a/docs/ex16_computer_details.rest
+++ b/docs/ex16_computer_details.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 16: Get computer details
 ================================
 
-The method **ex16_computer_details** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex16_computer_details** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -39,7 +44,8 @@ Send HTTP GET request to the  system URI(s).
  for instance in instances:
      response = restobj.rest_get(instance["href"])
 
-For each system print manufacturer, model and serial number from the response body..
+For each system print manufacturer, model and serial number from the response
+body.
 
 .. code-block:: python
 

--- a/docs/ex17_mount_virtual_media_iso.rest
+++ b/docs/ex17_mount_virtual_media_iso.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,12 @@ Redfish Object creation:
 Example 17: Mount virtual media ISO
 ===================================
 
-The method **ex17_mount_virtual_media_iso** takes an instance of rest object ( redfish object if using Redfish API ) ,  ISO image url and boolean boot on next server as arguments. The method mounts an ISO to virtual media and optionally specifies whether it should be the boot target for the next server reset. If iso_url is left out, it unmounts the iso image. If boot_on_next_server_reset is left out the option is not set.
+The method **ex17_mount_virtual_media_iso** takes an instance of rest object
+(redfish object if using Redfish API), ISO image url and boolean boot on next
+server as arguments. The method mounts an ISO to virtual media and optionally
+specifies whether it should be the boot target for the next server reset. If
+iso_url is left out, it unmounts the iso image. If boot_on_next_server_reset is
+left out the option is not set.
 
 .. code-block:: python
 
@@ -39,7 +48,8 @@ Send HTTP GET request to the  manager URI(s).
  for instance in instances:
      rsp = restobj.rest_get(instance["href"])
 
-Virtual media URI link found from the response body is used for another GET request.
+Virtual media URI link found from the response body is used for another GET
+request.
 
 .. code-block:: python
  
@@ -52,7 +62,8 @@ For each virtual media link URI send a GET request.
  for vmlink in rsp.dict["links"]["Member"]:
      response = restobj.rest_get(vmlink["href"])
 
-For each virtual media link with successful respone status and dvd media type support, prepare the request body.
+For each virtual media link with successful respone status and dvd media type
+support, prepare the request body.
 
 .. code-block:: python
 
@@ -64,7 +75,8 @@ For each virtual media link with successful respone status and dvd media type su
          body["Oem"] = {"Hp": {"BootOnNextServerReset": \
                         boot_on_next_server_reset}}
 
-PATCH request is performed  and the response is checked, response 400 is found if virtual media is already in this state.
+PATCH request is performed and the response is checked, response 400 is found
+if virtual media is already in this state.
 
 .. code-block:: python
 

--- a/docs/ex17_mount_virtual_media_iso.rest
+++ b/docs/ex17_mount_virtual_media_iso.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,16 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
-
 
 Example 17: Mount virtual media ISO
 ===================================
@@ -29,66 +24,49 @@ The method **ex17_mount_virtual_media_iso** takes an instance of rest object ( r
 
 .. code-block:: python
 
-  def ex17_mount_virtual_media_iso(restobj, iso_url, boot_on_next_server_reset):
+ def ex17_mount_virtual_media_iso(restobj, iso_url, boot_on_next_server_reset):
 
-::
-
-Find and get the system resource for manager. 
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Manager.")
-
-::
-
+ instances = restobj.search_for_type("Manager.")
 
 Send HTTP GET request to the  manager URI(s).
 
 .. code-block:: python
 
-   for instance in instances:
-        rsp = restobj.rest_get(instance["href"])
-::
+ for instance in instances:
+     rsp = restobj.rest_get(instance["href"])
 
 Virtual media URI link found from the response body is used for another GET request.
 
 .. code-block:: python
-
-  
-        rsp = restobj.rest_get(rsp.dict["links"]["VirtualMedia"]["href"])
-
-::
-
+ 
+ rsp = restobj.rest_get(rsp.dict["links"]["VirtualMedia"]["href"])
 
 For each virtual media link URI send a GET request.
 
 .. code-block:: python
 
-  for vmlink in rsp.dict["links"]["Member"]:
-            response = restobj.rest_get(vmlink["href"])
-
-::
+ for vmlink in rsp.dict["links"]["Member"]:
+     response = restobj.rest_get(vmlink["href"])
 
 For each virtual media link with successful respone status and dvd media type support, prepare the request body.
 
 .. code-block:: python
 
-            if response.status == 200 and "DVD" in response.dict["MediaTypes"]:
-                body = {"Image": iso_url}
-                
-                if (iso_url is not None and \
-                                        boot_on_next_server_reset is not None):
-                    body["Oem"] = {"Hp": {"BootOnNextServerReset": \
-                                                    boot_on_next_server_reset}}
-    
-::
+ if response.status == 200 and "DVD" in response.dict["MediaTypes"]:
+     body = {"Image": iso_url}
+
+     if (iso_url is not None and \
+         boot_on_next_server_reset is not None):
+         body["Oem"] = {"Hp": {"BootOnNextServerReset": \
+                        boot_on_next_server_reset}}
 
 PATCH request is performed  and the response is checked, response 400 is found if virtual media is already in this state.
 
 .. code-block:: python
 
-                 response = restobj.rest_patch(vmlink["href"], body)
-                 restobj.error_handler(response)
-           
-:: 
+ response = restobj.rest_patch(vmlink["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex18_set_server_asset_tag.rest
+++ b/docs/ex18_set_server_asset_tag.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,61 +11,37 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
-
 Example 18: Set server asset tag
 ================================
 
 The method **ex18_set_server_asset_tag** takes an instance of rest object ( or redfish object if using Redfish API ) and asset tag to be set as arguments.
 
+.. code-block:: python
+
+ def ex18_set_server_asset_tag(restobj, asset_tag):
+
+Find and get the system resource for computer system.
 
 .. code-block:: python
 
-
-    def ex18_set_server_asset_tag(restobj, asset_tag):
-
-
-::
-
-
-Find and get the system resource for computer system. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("ComputerSystem.")
-
-::
-
+ instances = restobj.search_for_type("ComputerSystem.")
 
 For each system for the systems collection asset tag parameter is set as the body for PATCH request.
 
-
-
 .. code-block:: python
 
-           for instance in instances:
-               body = {"AssetTag": asset_tag}
-
-::
-
-
+ for instance in instances:
+      body = {"AssetTag": asset_tag}
 
 The PATCH request is performed with the asset tag in the body.
 
 .. code-block:: python
 
-        response = restobj.rest_patch(instance["href"], body)
-        restobj.error_handler(response)
-
-::
+ response = restobj.rest_patch(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex18_set_server_asset_tag.rest
+++ b/docs/ex18_set_server_asset_tag.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 18: Set server asset tag
 ================================
 
-The method **ex18_set_server_asset_tag** takes an instance of rest object ( or redfish object if using Redfish API ) and asset tag to be set as arguments.
+The method **ex18_set_server_asset_tag** takes an instance of rest object (or
+redfish object if using Redfish API) and asset tag to be set as arguments.
 
 .. code-block:: python
 
@@ -32,7 +37,8 @@ Find and get the system resource for computer system.
 
  instances = restobj.search_for_type("ComputerSystem.")
 
-For each system for the systems collection asset tag parameter is set as the body for PATCH request.
+For each system for the systems collection asset tag parameter is set as the
+body for PATCH request.
 
 .. code-block:: python
 

--- a/docs/ex19_reset_ilo.rest
+++ b/docs/ex19_reset_ilo.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 19: Reset iLO
 =====================
 
-The method **ex19_reset_ilo** takes an instance of rest object( or redfish object if using Redfish API)  as argument.
+The method **ex19_reset_ilo** takes an instance of rest object (or redfish
+object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex19_reset_ilo.rest
+++ b/docs/ex19_reset_ilo.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,57 +11,37 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 19: Reset iLO
-================================
+=====================
 
 The method **ex19_reset_ilo** takes an instance of rest object( or redfish object if using Redfish API)  as argument.
 
+.. code-block:: python
+
+ def ex19_reset_ilo(restobj):
+
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-
-    def ex19_reset_ilo(restobj):
-
-
-::
-
-
-Find and get the system resource for manager. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("Manager.")
-
-::
-
-
+ instances = restobj.search_for_type("Manager.")
 
 Action reset request is added for the POST request body.
 
 .. code-block:: python
 
-   for instance in instances:
-        body = {"Action": "Reset"}
+ for instance in instances:
+     body = {"Action": "Reset"}
 
-::
-  
 POST request for iLO reset is performed and response status is checked.
 
 .. code-block:: python
 
-        response = restobj.rest_post(instance["href"], body)
-        restobj.error_handler(response)
-
-::
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex1_get_resource_directory.rest
+++ b/docs/ex1_get_resource_directory.rest
@@ -1,11 +1,10 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -15,61 +14,47 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 1: Get resource directory
 =================================
-
 
 The method **ex1_get_resource_directory** takes an instance of rest object (or redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
+ def ex1_get_resource_directory(restobj):
 
-  def ex1_get_resource_directory(restobj):
-
-::
-
-A Restful GET request is performed next  by calling the Rest object's get method  with the resource directory URI ('**/rest/v1/resourcedirectory**') as parameter.  For Redfish RESTful request the URI is ('**/redfish/v1/resourcedirectory**')
+A Restful GET request is performed next  by calling the Rest object's get method with the resource directory URI ('**/rest/v1/resourcedirectory**') as parameter. For Redfish RESTful request the URI is ('**/redfish/v1/resourcedirectory**')
 
 .. code-block:: python
 
  response = restobj.rest_get("/rest/v1/resourcedirectory")
-
-::
 
 For a successful response status, resource directory is retrieved from the response body.
 
 .. code-block:: python
 
  if response.status == 200:
-        sys.stdout.write("\tFound resource directory at /rest/v1/resource" \
-                                                            "directory" + "\n\n")
-        SYSTEMS_RESOURCES["resources"] = response.dict["Instances"]
-        
- else:
-        sys.stderr.write("\tResource directory missing at /rest/v1/resource" \
-                                                            "directory" + "\n")
+     sys.stdout.write("\tFound resource directory at /rest/v1/resource" \
+                      "directory" + "\n\n")
+     SYSTEMS_RESOURCES["resources"] = response.dict["Instances"]
 
-::
+ else:
+     sys.stderr.write("\tResource directory missing at /rest/v1/resource" \
+                      "directory" + "\n")
 
 Nested within the if, else statement, resources are listed by type and URI. A try and except is used to skip those without types.
 
 .. code-block:: python
 
  for resource in response.dict["Instances"]:
-    try:
-    sys.stdout.write("\t" + str(resource["@odata.type"]) + \
-                           "\n\t\t" + str(resource["@odata.id"]) + "\n")
-    except KeyError:
+     try:
+     sys.stdout.write("\t" + str(resource["@odata.type"]) + \
+                      "\n\t\t" + str(resource["@odata.id"]) + "\n")
+     except KeyError:
         pass
-::

--- a/docs/ex1_get_resource_directory.rest
+++ b/docs/ex1_get_resource_directory.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,19 +27,24 @@ Redfish Object creation:
 Example 1: Get resource directory
 =================================
 
-The method **ex1_get_resource_directory** takes an instance of rest object (or redfish object if using Redfish API) as argument.
+The method **ex1_get_resource_directory** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
  def ex1_get_resource_directory(restobj):
 
-A Restful GET request is performed next  by calling the Rest object's get method with the resource directory URI ('**/rest/v1/resourcedirectory**') as parameter. For Redfish RESTful request the URI is ('**/redfish/v1/resourcedirectory**')
+A Restful GET request is performed next by calling the Rest object's get
+method with the resource directory URI ('**/rest/v1/resourcedirectory**') as
+parameter. For Redfish RESTful request the URI is
+('**/redfish/v1/resourcedirectory**')
 
 .. code-block:: python
 
  response = restobj.rest_get("/rest/v1/resourcedirectory")
 
-For a successful response status, resource directory is retrieved from the response body.
+For a successful response status, resource directory is retrieved from the
+response body.
 
 .. code-block:: python
 
@@ -48,7 +57,8 @@ For a successful response status, resource directory is retrieved from the respo
      sys.stderr.write("\tResource directory missing at /rest/v1/resource" \
                       "directory" + "\n")
 
-Nested within the if, else statement, resources are listed by type and URI. A try and except is used to skip those without types.
+Nested within the if, else statement, resources are listed by type and URI. A
+try and except is used to skip those without types.
 
 .. code-block:: python
 

--- a/docs/ex20_get_ilo_nic.rest
+++ b/docs/ex20_get_ilo_nic.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 20: Get iLO NIC
 =======================
 
-The method **ex20_get_ilo_nic** takes an instance of rest object ( or redfish object if using Redfish API )  and active flag as arguments.
+The method **ex20_get_ilo_nic** takes an instance of rest object (or redfish
+object if using Redfish API) and active flag as arguments.
 
 .. code-block:: python
 

--- a/docs/ex20_get_ilo_nic.rest
+++ b/docs/ex20_get_ilo_nic.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,16 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
-
 
 Example 20: Get iLO NIC
 =======================
@@ -31,50 +24,35 @@ The method **ex20_get_ilo_nic** takes an instance of rest object ( or redfish ob
 
 .. code-block:: python
 
-  def ex20_get_ilo_nic(restobj, get_active):
+ def ex20_get_ilo_nic(restobj, get_active):
 
-::
-
-Find and get the system resource for manager. 
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Manager.")
-
-::
+ instances = restobj.search_for_type("Manager.")
 
 Send a HTTP GET request to the  manager URI(s).
 
 .. code-block:: python
 
-      for instance in instances:
-          tmp = restobj.rest_get(instance["href"]) 
-
-::
+ for instance in instances:
+     tmp = restobj.rest_get(instance["href"])
 
 Send another GET request to the ethernet interfaces URI.
 
 .. code-block:: python
-
   
-   response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
-
-
-::
+ response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
 
 Print the active NIC from the response body.
 
 .. code-block:: python
 
-   for nic in response.dict["Items"]:
-            if get_active and nic["Status"]["State"] == "Enabled":
-                sys.stdout.write("Active\t" + nic["links"]["self"]["href"] + \
-                                                ": " + json.dumps(nic) + "\n")
-            elif get_active == False and nic["Status"]["State"] == "Disabled":
-                sys.stdout.write("InActive\t" + nic["links"]["self"]["href"] + \
-                                                ": " + json.dumps(nic) + "\n")
-
-::
-
-
+ for nic in response.dict["Items"]:
+     if get_active and nic["Status"]["State"] == "Enabled":
+         sys.stdout.write("Active\t" + nic["links"]["self"]["href"] + \
+                          ": " + json.dumps(nic) + "\n")
+     elif get_active == False and nic["Status"]["State"] == "Disabled":
+         sys.stdout.write("InActive\t" + nic["links"]["self"]["href"] + \
+                          ": " + json.dumps(nic) + "\n")

--- a/docs/ex21_set_active_ilo_nic.rest
+++ b/docs/ex21_set_active_ilo_nic.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 21: Set iLO NIC active
 ==============================
 
-The method **ex21_set_active_ilo_nic** takes an instance of rest object (or redfish object if using Redfish API)  and shared nic boolean as arguments.
+The method **ex21_set_active_ilo_nic** takes an instance of rest object (or
+redfish object if using Redfish API) and shared nic boolean as arguments.
 
 .. code-block:: python
 

--- a/docs/ex21_set_active_ilo_nic.rest
+++ b/docs/ex21_set_active_ilo_nic.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 21: Set iLO NIC active
 ==============================
@@ -28,90 +24,65 @@ The method **ex21_set_active_ilo_nic** takes an instance of rest object (or redf
 
 .. code-block:: python
 
-  def ex21_set_active_ilo_nic(restobj, shared_nic):
+ def ex21_set_active_ilo_nic(restobj, shared_nic):
 
-::
-
-Find and get the system resource for manager. 
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Manager.")
-
-::
+ instances = restobj.search_for_type("Manager.")
 
 Send a HTTP GET request to the  manager URI(s).
 
 .. code-block:: python
 
-      for instance in instances:
-          tmp = restobj.rest_get(instance["href"]) 
-
-::
+ for instance in instances:
+     tmp = restobj.rest_get(instance["href"])
 
 Send another GET request to the ethernet interfaces URI.
 
 .. code-block:: python
 
-  
-   response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
+ response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
 
-
-::
-
-Find the iLO NIC URI from the response body. 
+Find the iLO NIC URI from the response body.
 
 .. code-block:: python
+ 
+ for nic in response.dict["Items"]:
+      try:
+          if (nic["Oem"]["Hp"]["SupportsFlexibleLOM"] == True and \
+                                                         shared_nic == True):
+              selected_nic_uri = nic["links"]["self"]["href"]
+              break
+      except KeyError:
+          pass
 
-  
-   for nic in response.dict["Items"]:
-         try:
-            if (nic["Oem"]["Hp"]["SupportsFlexibleLOM"] == True and \
-                                                            shared_nic == True):
-                selected_nic_uri = nic["links"]["self"]["href"]
-                break
-         except KeyError:
-            pass
-    
-         try:
-            if (nic["Oem"]["Hp"]["SupportsLOM"] == True and \
-                                                            shared_nic == True):
-                selected_nic_uri = nic["links"]["self"]["href"]
-                break
-         except KeyError:
-            pass
-    
-         if not shared_nic:
-            selected_nic_uri = nic["links"]["self"]["href"]
-            break
-         elif not selected_nic_uri:
-            sys.stderr.write("\tShared NIC is not supported\n")
-            break
+      try:
+          if (nic["Oem"]["Hp"]["SupportsLOM"] == True and \
+                                                 shared_nic == True):
+              selected_nic_uri = nic["links"]["self"]["href"]
+              break
+      except KeyError:
+          pass
 
-::
+      if not shared_nic:
+          selected_nic_uri = nic["links"]["self"]["href"]
+          break
+      elif not selected_nic_uri:
+          sys.stderr.write("\tShared NIC is not supported\n")
+          break
 
 Set the request body.
 
 .. code-block:: python
 
-   if selected_nic_uri:
-            body = {"Oem": {"Hp": {"NICEnabled": True}}}
-
-::
+ if selected_nic_uri:
+     body = {"Oem": {"Hp": {"NICEnabled": True}}}
 
 Perform PATCH request.
 
 .. code-block:: python
 
-          response = restobj.rest_patch(selected_nic_uri, body)
-          restobj.error_handler(response)
-
-::
-
-
-
-
-
-
- 
+ response = restobj.rest_patch(selected_nic_uri, body)
+ restobj.error_handler(response)

--- a/docs/ex22_dump_iml.rest
+++ b/docs/ex22_dump_iml.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 22: Dump Integrated Management Log
 ==========================================
@@ -30,41 +24,28 @@ The method **def ex22_dump_iml** takes an instance of rest object ( or redfish o
 
 .. code-block:: python
 
+ def ex22_dump_iml(restobj):
 
-  def ex22_dump_iml(restobj):
-
-::
-
-
-Find and get the system resource for log service. 
+Find and get the system resource for log service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("LogService.")
-
-::
+ instances = restobj.search_for_type("LogService.")
 
 Send HTTP GET request to log service IML URI(s).
 
 .. code-block:: python
 
-     for instance in instances:
-        if instance["href"].endswith("IML"):
-            tmp = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     if instance["href"].endswith("IML"):
+         tmp = restobj.rest_get(instance["href"])
 
 Send another GET request to IML entries URI.
 
 .. code-block:: python
 
-        for entry in tmp.dict["links"]["Entries"]:
-            response = restobj.rest_get(entry["href"])
-::
-
-
-
+ for entry in tmp.dict["links"]["Entries"]:
+     response = restobj.rest_get(entry["href"])
 
 From the IML entries link response print log entry.
 
@@ -75,5 +56,3 @@ From the IML entries link response print log entry.
                       str(log_entry["Oem"]["Hp"]["Class"]) + \
                       " / Code " + str(log_entry["Oem"]["Hp"]["Code"]) + \
                       ":\t" + log_entry["Message"] + "\n")
-
-::

--- a/docs/ex22_dump_iml.rest
+++ b/docs/ex22_dump_iml.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 22: Dump Integrated Management Log
 ==========================================
 
-The method **def ex22_dump_iml** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **def ex22_dump_iml** takes an instance of rest object (or redfish
+object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex23_dump_ilo_event_log.rest
+++ b/docs/ex23_dump_ilo_event_log.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 23: Get iLO Event Log
 =============================
 
-The method **ex23_dump_ilo_event_log** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex23_dump_ilo_event_log** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex23_dump_ilo_event_log.rest
+++ b/docs/ex23_dump_ilo_event_log.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 23: Get iLO Event Log
 =============================
@@ -29,44 +24,32 @@ The method **ex23_dump_ilo_event_log** takes an instance of rest object ( or red
 
 .. code-block:: python
 
-  def ex23_dump_ilo_event_log(restobj):
+ def ex23_dump_ilo_event_log(restobj):
 
-::
-
-Find and get the system resource for log service. 
+Find and get the system resource for log service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("LogService.")
-
-::
+ instances = restobj.search_for_type("LogService.")
 
 Send HTTP GET request to log service IEL URI(s).
 
 .. code-block:: python
 
-     for instance in instances:
-        if instance["href"].endswith("IEL"):
-            tmp = restobj.rest_get(instance["href"])
-::
+ for instance in instances:
+     if instance["href"].endswith("IEL"):
+         tmp = restobj.rest_get(instance["href"])
 
 Send another GET request to IEL entries URI.
 
 .. code-block:: python
 
-        for entry in tmp.dict["links"]["Entries"]:
-            response = restobj.rest_get(entry["href"])
-::
-
-
-
+ for entry in tmp.dict["links"]["Entries"]:
+     response = restobj.rest_get(entry["href"])
 
 From the IEL entries link response print log entry messages.
 
 .. code-block:: python
 
-        for log_entry in response.dict["Items"]:
-            sys.stdout.write(log_entry["Message"] + "\n")
-
-::
+ for log_entry in response.dict["Items"]:
+     sys.stdout.write(log_entry["Message"] + "\n")

--- a/docs/ex24_clear_iml.rest
+++ b/docs/ex24_clear_iml.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,58 +11,38 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 24: Clear Integrated Management Log
-==========================================
+===========================================
 
 The method **ex24_clear_iml** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ def ex24_clear_iml(restobj):
+
+Find and get the system resource for log service.
 
 .. code-block:: python
 
-
-  def ex24_clear_iml(restobj):
-
-::
-
-
-Find and get the system resource for log service. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("LogService.")
-
-::
-
+ instances = restobj.search_for_type("LogService.")
 
 Prepare request body to clear log.
 
 .. code-block:: python
 
-      for instance in instances:
-        if instance["href"].endswith("IML"):
-            body = {"Action": "ClearLog"}
-
-
-::
-
-
+ for instance in instances:
+     if instance["href"].endswith("IML"):
+         body = {"Action": "ClearLog"}
 
 Perform POST request to clear the log.
 
 .. code-block:: python
 
-            response = restobj.rest_post(instance["href"], body)
-            restobj.error_handler(response)
-
-::
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex24_clear_iml.rest
+++ b/docs/ex24_clear_iml.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 24: Clear Integrated Management Log
 ===========================================
 
-The method **ex24_clear_iml** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex24_clear_iml** takes an instance of rest object (or redfish
+object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex25_clear_ilo_event_log.rest
+++ b/docs/ex25_clear_ilo_event_log.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,16 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
-
 
 Example 25: Clear iLO Event Log
 ===============================
@@ -29,35 +24,25 @@ The method **ex25_clear_ilo_event_log** takes an instance of rest object ( or re
 
 .. code-block:: python
 
-  def ex25_clear_ilo_event_log(restobj):
+ def ex25_clear_ilo_event_log(restobj):
 
-::
-
-Find and get the system resource for log service. 
+Find and get the system resource for log service.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("LogService.")
-
-::
+ instances = restobj.search_for_type("LogService.")
 
 Prepare request body to clear log.
 
 .. code-block:: python
 
-      for instance in instances:
-        if instance["href"].endswith("IEL"):
-            body = {"Action": "ClearLog"}
-
-
-::
+ for instance in instances:
+     if instance["href"].endswith("IEL"):
+         body = {"Action": "ClearLog"}
 
 Perform POST request to clear the log.
 
 .. code-block:: python
 
-            response = restobj.rest_post(instance["href"], body)
-            restobj.error_handler(response)
-
-::
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex25_clear_ilo_event_log.rest
+++ b/docs/ex25_clear_ilo_event_log.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 25: Clear iLO Event Log
 ===============================
 
-The method **ex25_clear_ilo_event_log** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex25_clear_ilo_event_log** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex26_configure_snmp.rest
+++ b/docs/ex26_configure_snmp.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 26: configure SNMP
 ==========================
 
-The method **ex26_configure_snmp** takes an instance of rest object ( or redfish object if using Redfish API ), snmp mode and alerts as arguments.
+The method **ex26_configure_snmp** takes an instance of rest object (or redfish
+object if using Redfish API), snmp mode and alerts as arguments.
 
 .. code-block:: python
 

--- a/docs/ex26_configure_snmp.rest
+++ b/docs/ex26_configure_snmp.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 26: configure SNMP
 ==========================
@@ -29,32 +24,24 @@ The method **ex26_configure_snmp** takes an instance of rest object ( or redfish
 
 .. code-block:: python
 
-  def ex26_configure_snmp(restobj, snmp_mode, snmp_alerts):
-::
+ def ex26_configure_snmp(restobj, snmp_mode, snmp_alerts):
 
-Find and get the system resource for snmp service. 
+Find and get the system resource for snmp service.
 
 .. code-block:: python
 
-     instances = restobj.search_for_type("SnmpService.")
-
-::
+ instances = restobj.search_for_type("SnmpService.")
 
 Prepare request body with the snmp mode and alerts parameters provided.
 
 .. code-block:: python
 
-      for instance in instances:
-        body = {"Mode": snmp_mode, "AlertsEnabled": snmp_alerts}
-
-
-::
+ for instance in instances:
+     body = {"Mode": snmp_mode, "AlertsEnabled": snmp_alerts}
 
 Perform PATCH request and check response.
 
 .. code-block:: python
 
-            response = restobj.rest_patch(instance["href"], body)
-            restobj.error_handler(response)
-::
-
+ response = restobj.rest_patch(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex27_get_schema.rest
+++ b/docs/ex27_get_schema.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 27: Get schema
 ======================
@@ -28,48 +24,38 @@ The method **ex27_get_schema** takes an instance of rest object ( or redfish obj
 
 .. code-block:: python
 
-  def ex27_get_schema(restobj, schema_prefix):
+ def ex27_get_schema(restobj, schema_prefix):
 
-::
-
-Send HTTP GET request to schema URI '/rest/v1/Schemas'.  
+Send HTTP GET request to schema URI '/rest/v1/Schemas'.
 
 .. code-block:: python
 
-
-     response = restobj.rest_get("/rest/v1/Schemas")
-::
-
-
+ response = restobj.rest_get("/rest/v1/Schemas")
 
 From the response body find the requested schema URI.
 
 .. code-block:: python
 
-      for schema in response.dict["Items"]:
-        if schema["Schema"].startswith(schema_prefix):
-            for location in schema["Location"]:
-                extref_uri = location["Uri"]["extref"]
-::
+ for schema in response.dict["Items"]:
+    if schema["Schema"].startswith(schema_prefix):
+        for location in schema["Location"]:
+            extref_uri = location["Uri"]["extref"]
 
 Get the schema with the requested schema prefix through GET  request.
 
 .. code-block:: python
 
-        response = restobj.rest_get(extref_uri)
-::
+ response = restobj.rest_get(extref_uri)
 
 Check the status.
 
 .. code-block:: python
 
-                if response.status == 200:
-                    sys.stdout.write("\tFound " + schema_prefix + " at "\
-                                                        + extref_uri + "\n")
-                    return
-                else:
-                    sys.stderr.write("\t" + schema_prefix + " not found at " \
-                                                        + extref_uri + "\n")
-                    return
-
-::
+ if response.status == 200:
+     sys.stdout.write("\tFound " + schema_prefix + " at "\
+                      + extref_uri + "\n")
+     return
+ else:
+     sys.stderr.write("\t" + schema_prefix + " not found at " \
+                      + extref_uri + "\n")
+     return

--- a/docs/ex27_get_schema.rest
+++ b/docs/ex27_get_schema.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 27: Get schema
 ======================
 
-The method **ex27_get_schema** takes an instance of rest object ( or redfish object if using Redfish API ) and schema prefix as arguments.
+The method **ex27_get_schema** takes an instance of rest object (or redfish
+object if using Redfish API) and schema prefix as arguments.
 
 .. code-block:: python
 
@@ -41,7 +46,7 @@ From the response body find the requested schema URI.
         for location in schema["Location"]:
             extref_uri = location["Uri"]["extref"]
 
-Get the schema with the requested schema prefix through GET  request.
+Get the schema with the requested schema prefix through GET request.
 
 .. code-block:: python
 

--- a/docs/ex28_set_ilo_timezone.rest
+++ b/docs/ex28_set_ilo_timezone.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 28: Set iLO time zone
 =============================
@@ -30,47 +24,32 @@ The method **ex28_set_ilo_timezone** takes an instance of rest object ( or redfi
 
 .. code-block:: python
 
-  def ex28_set_ilo_timezone(restobj, olson_timezone):
+ def ex28_set_ilo_timezone(restobj, olson_timezone):
 
-::
-
-Find and get the system resource for iLO date time. 
+Find and get the system resource for iLO date time.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("HpiLODateTime.")
-
-::
+ instances = restobj.search_for_type("HpiLODateTime.")
 
 Send HTTP GET request to iLO date time URI.
 
 .. code-block:: python
 
-          for instance in instances:
-             response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 Find the time zone requested and prepare the request body.
 
 .. code-block:: python
 
-  for timezone in response.dict["TimeZoneList"]:
+ for timezone in response.dict["TimeZoneList"]:
      if timezone["Name"].startswith(olson_timezone):
         body = {"TimeZone": {"Index": timezone["Index"]}}
-
-::
 
 Perform PATCH request to update iLO time zone.
 
 .. code-block:: python
 
-                response = restobj.rest_patch(instance["href"], body)
-                restobj.error_handler(response)
-
-::
-
- 
-
-
+ response = restobj.rest_patch(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex28_set_ilo_timezone.rest
+++ b/docs/ex28_set_ilo_timezone.rest
@@ -3,7 +3,7 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +20,10 @@ Redfish Object creation:
 Example 28: Set iLO time zone
 =============================
 
-The method **ex28_set_ilo_timezone** takes an instance of rest object ( or redfish object if using Redfish API ) and  expected time zone as arguments. The method only works if iLO is not configured to take the time settings from DHCP v4 or v6.
+The method **ex28_set_ilo_timezone** takes an instance of rest object (or
+redfish object if using Redfish API) and expected time zone as arguments. The
+method only works if iLO is not configured to take the time settings from DHCP
+v4 or v6.
 
 .. code-block:: python
 

--- a/docs/ex29_set_ilo_ntp_servers.rest
+++ b/docs/ex29_set_ilo_ntp_servers.rest
@@ -1,6 +1,6 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
@@ -11,59 +11,43 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 29: Set iLO NTP servers
 ===============================
 
 The method **ex29_set_ilo_ntp_servers** takes an instance of rest object ( or redfish object if using Redfish API ) and  NTP server list as arguments. The method doesn't work if SNTP configuration is currently managed by DHCP and is therefore read-only.
 
+.. code-block:: python
+
+ def ex29_set_ilo_ntp_servers(restobj, ntp_servers):
+
+Find and get the system resource for iLO date time.
 
 .. code-block:: python
 
-  def ex29_set_ilo_ntp_servers(restobj, ntp_servers):
-::
-
-Find and get the system resource for iLO date time. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("HpiLODateTime.")
-
-::
+ instances = restobj.search_for_type("HpiLODateTime.")
 
 Send HTTP GET request to iLO date time URI.
 
 .. code-block:: python
 
-          for instance in instances:
-             response = restobj.rest_get(instance["href"])
-
-::
-
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 Prepare the PATCH request body with NTP server list provided.
 
 .. code-block:: python
 
-  body = {"StaticNTPServers": ntp_servers}
-
-       
-::
+ body = {"StaticNTPServers": ntp_servers}
 
 Perform  PATCH request and check response.
 
 .. code-block:: python
 
-        response = restobj.rest_patch(instance["href"], body)
-        restobj.error_handler(response)
-::
+ response = restobj.rest_patch(instance["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex29_set_ilo_ntp_servers.rest
+++ b/docs/ex29_set_ilo_ntp_servers.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,10 @@ Redfish Object creation:
 Example 29: Set iLO NTP servers
 ===============================
 
-The method **ex29_set_ilo_ntp_servers** takes an instance of rest object ( or redfish object if using Redfish API ) and  NTP server list as arguments. The method doesn't work if SNTP configuration is currently managed by DHCP and is therefore read-only.
+The method **ex29_set_ilo_ntp_servers** takes an instance of rest object (or
+redfish object if using Redfish API) and NTP server list as arguments. The
+method doesn't work if SNTP configuration is currently managed by DHCP and is
+therefore read-only.
 
 .. code-block:: python
 
@@ -45,7 +52,7 @@ Prepare the PATCH request body with NTP server list provided.
 
  body = {"StaticNTPServers": ntp_servers}
 
-Perform  PATCH request and check response.
+Perform PATCH request and check response.
 
 .. code-block:: python
 

--- a/docs/ex2_get_base_registry.rest
+++ b/docs/ex2_get_base_registry.rest
@@ -1,11 +1,10 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -15,29 +14,20 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 2: Get base registry
 ============================
-
 
 The method **ex2_get_base_registry** takes an instance of rest object ( or redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
-
-  def ex2_get_base_registry(restobj):
-
-::
+ def ex2_get_base_registry(restobj):
 
 A Restful GET request is performed next  by calling the Rest object's get method  with the registries uri ('**/rest/v1/registries**') as parameter.  For Redfish RESTful request the URI is ('**/redfish/v1/registries**')
 
@@ -45,31 +35,24 @@ A Restful GET request is performed next  by calling the Rest object's get method
 
  response = restobj.rest_get("/rest/v1/Registries")
 
-::
-
-From the response body for each "Location" in "Items" with "Base" or "iLO" Id , a GET request in performed with the URI retrieved from ["Location"]["Uri"]["extref"]. 
+From the response body for each "Location" in "Items" with "Base" or "iLO" Id , a GET request in performed with the URI retrieved from ["Location"]["Uri"]["extref"].
 
 .. code-block:: python
 
  for entry in response.dict["Items"]:
-        if entry["Id"] not in ["Base", "iLO"]:
-            continue
-        for location in entry["Location"]:  
-            reg_resp = restobj.rest_get(location["Uri"]["extref"])
-
-::
+     if entry["Id"] not in ["Base", "iLO"]:
+         continue
+     for location in entry["Location"]:
+         reg_resp = restobj.rest_get(location["Uri"]["extref"])
 
 For successful response status, messages are added to MESSAGE_REGISTRIES.
 
 .. code-block:: python
 
-            if reg_resp.status == 200:
-                sys.stdout.write("\tFound " + entry["Id"] + " at " + \
-                                            location["Uri"]["extref"] + "\n")
-                MESSAGE_REGISTRIES[entry["Id"]] = reg_resp.dict["Messages"]                
-            else:
-                sys.stdout.write("\t" + entry["Id"] + " not found at "\
-                                            + location["Uri"]["extref"] + "\n")
- 
-::
-
+ if reg_resp.status == 200:
+     sys.stdout.write("\tFound " + entry["Id"] + " at " + \
+                      location["Uri"]["extref"] + "\n")
+     MESSAGE_REGISTRIES[entry["Id"]] = reg_resp.dict["Messages"]
+ else:
+     sys.stdout.write("\t" + entry["Id"] + " not found at "\
+                      + location["Uri"]["extref"] + "\n")

--- a/docs/ex2_get_base_registry.rest
+++ b/docs/ex2_get_base_registry.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,19 +27,24 @@ Redfish Object creation:
 Example 2: Get base registry
 ============================
 
-The method **ex2_get_base_registry** takes an instance of rest object ( or redfish object if using Redfish API) as argument.
+The method **ex2_get_base_registry** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
  def ex2_get_base_registry(restobj):
 
-A Restful GET request is performed next  by calling the Rest object's get method  with the registries uri ('**/rest/v1/registries**') as parameter.  For Redfish RESTful request the URI is ('**/redfish/v1/registries**')
+A Restful GET request is performed next by calling the Rest object's get method
+with the registries uri ('**/rest/v1/registries**') as parameter. For Redfish
+RESTful request the URI is ('**/redfish/v1/registries**')
 
 .. code-block:: python
 
  response = restobj.rest_get("/rest/v1/Registries")
 
-From the response body for each "Location" in "Items" with "Base" or "iLO" Id , a GET request in performed with the URI retrieved from ["Location"]["Uri"]["extref"].
+From the response body for each "Location" in "Items" with "Base" or "iLO" Id ,
+a GET request in performed with the URI retrieved from
+["Location"]["Uri"]["extref"].
 
 .. code-block:: python
 

--- a/docs/ex30_get_powermetrics_average.rest
+++ b/docs/ex30_get_powermetrics_average.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,60 +11,45 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 30: Get power metrics average
 =====================================
 
-The method **ex30_get_powermetrics_average** takes an instance of rest object ( or redfish object if using Redfish API ) as argument. 
+The method **ex30_get_powermetrics_average** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
 .. code-block:: python
 
-  def ex30_get_powermetrics_average(restobj):
+ def ex30_get_powermetrics_average(restobj):
 
-::
-
-Find and get the system resource for power metrics. 
+Find and get the system resource for power metrics.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("PowerMetrics.")
-
-
-::
+ instances = restobj.search_for_type("PowerMetrics.")
 
 Send HTTP GET request to power metrics URI.
 
 .. code-block:: python
 
-          for instance in instances:
-             response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 From the response body get the average and print.
 
 .. code-block:: python
 
-        if "PowerMetrics" not in response.dict or \
-            "AverageConsumedWatts" not in response.dict["PowerMetrics"] or \
-                        "IntervalInMin" not in response.dict["PowerMetrics"]:
-            sys.stdout.write("\tPowerMetrics resource does not contain "\
-                       "'AverageConsumedWatts' or 'IntervalInMin' property\n")
-        else:
-            sys.stdout.write("\t" + " AverageConsumedWatts = " + \
-                 str(response.dict["PowerMetrics"]["AverageConsumedWatts"]) + \
-                 " watts over a " + str(response.dict["PowerMetrics"]\
-                                ["IntervalInMin"]) + " minute moving average\n")
-       
-::
-
+ if "PowerMetrics" not in response.dict or \
+     "AverageConsumedWatts" not in response.dict["PowerMetrics"] or \
+     "IntervalInMin" not in response.dict["PowerMetrics"]:
+     sys.stdout.write("\tPowerMetrics resource does not contain "\
+                      "'AverageConsumedWatts' or 'IntervalInMin' property\n")
+ else:
+     sys.stdout.write("\t" + " AverageConsumedWatts = " + \
+                      str(response.dict["PowerMetrics"]["AverageConsumedWatts"]) + \
+                      " watts over a " + str(response.dict["PowerMetrics"]\
+                      ["IntervalInMin"]) + " minute moving average\n")

--- a/docs/ex30_get_powermetrics_average.rest
+++ b/docs/ex30_get_powermetrics_average.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 30: Get power metrics average
 =====================================
 
-The method **ex30_get_powermetrics_average** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex30_get_powermetrics_average** takes an instance of rest object
+(or redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex31_set_license_key.rest
+++ b/docs/ex31_set_license_key.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 31: Set license key
 ===========================
 
-The method **ex31_set_ilicense_key** takes an instance of rest object ( or redfish object if using Redfish API ) and  iLO key as arguments.
+The method **ex31_set_ilicense_key** takes an instance of rest object (or
+redfish object if using Redfish API) and iLO key as arguments.
 
 .. code-block:: python
 
@@ -39,14 +44,14 @@ Send HTTP GET request to manager URI(s).
  for instance in instances:
      rsp = restobj.rest_get(instance["href"])
 
-Prepare the  request body with iLO license key provided.
+Prepare the request body with iLO license key provided.
 
 .. code-block:: python
 
  body = dict()
  body["LicenseKey"] = iLO_Key
 
-Perform  POST request and check response.
+Perform POST request and check response.
 
 .. code-block:: python
 

--- a/docs/ex31_set_license_key.rest
+++ b/docs/ex31_set_license_key.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,67 +11,45 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
-
 Example 31: Set license key
 ===========================
 
 The method **ex31_set_ilicense_key** takes an instance of rest object ( or redfish object if using Redfish API ) and  iLO key as arguments.
 
+.. code-block:: python
+
+ def ex31_set_license_key(restobj, iLO_Key):
+
+Find and get the system resource for manager.
 
 .. code-block:: python
 
-  def ex31_set_license_key(restobj, iLO_Key):
-
-::
-
-Find and get the system resource for manager. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("Manager.")
-::
-
+ instances = restobj.search_for_type("Manager.")
 
 Send HTTP GET request to manager URI(s).
 
 .. code-block:: python
 
-          for instance in instances:
-             rsp = restobj.rest_get(instance["href"])
-::
-
+ for instance in instances:
+     rsp = restobj.rest_get(instance["href"])
 
 Prepare the  request body with iLO license key provided.
 
 .. code-block:: python
 
-        body = dict()
-        body["LicenseKey"] = iLO_Key
-       
-::
+ body = dict()
+ body["LicenseKey"] = iLO_Key
 
 Perform  POST request and check response.
 
 .. code-block:: python
 
-        response = restobj.rest_post(rsp.dict["Oem"]["Hp"]["links"]
-                                     ["LicenseService"]["href"], body)
-        restobj.error_handler(response)
-
-::
-
-   
-
-  
+ response = restobj.rest_post(rsp.dict["Oem"]["Hp"]["links"]
+                              ["LicenseService"]["href"], body)
+ restobj.error_handler(response)

--- a/docs/ex32_set_bios_dhcp.rest
+++ b/docs/ex32_set_bios_dhcp.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 32: Set BIOS DHCP
 =============================
 
-The method **ex32_set_bios_dhcp** takes an instance of rest object ( or redfish object if using Redfish API ) and DHCP properties as arguments.
+The method **ex32_set_bios_dhcp** takes an instance of rest object (or redfish
+object if using Redfish API) and DHCP properties as arguments.
 
 .. code-block:: python
 

--- a/docs/ex32_set_bios_dhcp.rest
+++ b/docs/ex32_set_bios_dhcp.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 32: Set BIOS DHCP
 =============================
@@ -29,28 +24,22 @@ The method **ex32_set_bios_dhcp** takes an instance of rest object ( or redfish 
 
 .. code-block:: python
 
-  def ex32_set_bios_dhcp(restobj, bios_properties, bios_password=None):
-
-::
+ def ex32_set_bios_dhcp(restobj, bios_properties, bios_password=None):
 
 Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the DHCP settings prepare the request body with only the DHCP settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        response = restobj.rest_patch(instance["href"], bios_properties, \
-                                      bios_password)
-        restobj.error_handler(response)
-::
+ for instance in instances:
+     response = restobj.rest_patch(instance["href"], bios_properties, \
+                                   bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the DHCP values to the new values provided in DHCP settings, however the changes will go into effect only after a system reset or reboot.
 

--- a/docs/ex33_set_bios_service.rest
+++ b/docs/ex33_set_bios_service.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 33: Set BIOS services
 =============================
 
-The method **ex33_set_bios_service** takes an instance of rest object ( or redfish object if using Redfish API ) and BIOS service settings as arguments.
+The method **ex33_set_bios_service** takes an instance of rest object (or
+redfish object if using Redfish API) and BIOS service settings as arguments.
 
 .. code-block:: python
 

--- a/docs/ex33_set_bios_service.rest
+++ b/docs/ex33_set_bios_service.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 33: Set BIOS services
 =============================
@@ -29,28 +24,22 @@ The method **ex33_set_bios_service** takes an instance of rest object ( or redfi
 
 .. code-block:: python
 
-  def ex33_set_bios_service(restobj, bios_properties, bios_password=None):
-
-::
+ def ex33_set_bios_service(restobj, bios_properties, bios_password=None):
 
 Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the BIOS service settings, prepare the request body with only the BIOS service settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        response = restobj.rest_patch(instance["href"], bios_properties, \
-                                      bios_password)
-        restobj.error_handler(response)
-::
+ for instance in instances:
+     response = restobj.rest_patch(instance["href"], bios_properties, \
+                                   bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the BIOS service settings to the new values provided in BIOS settings, however the changes will go into effect only after a system reset or reboot.
 

--- a/docs/ex34_set_bios_uefi_shell_startup.rest
+++ b/docs/ex34_set_bios_uefi_shell_startup.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,45 +11,35 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 34: Set BIOS UEFI shell startup settings
-=============================
+================================================
 
 The method **ex34_set_bios_uefi_shell_startup** takes an instance of rest object ( or redfish object if using Redfish API ) and BIOS service settings as arguments.
 
 .. code-block:: python
 
-  def ex34_set_bios_uefi_shell_startup(restobj, uefienabled="Enabled", networkpath="", urlpath="", bios_password=None):
-
-::
+ def ex34_set_bios_uefi_shell_startup(restobj, uefienabled="Enabled", networkpath="", urlpath="", bios_password=None):
 
 Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the UEFI settings, prepare the request body with only the UEFI settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-	def setproperty (restobj,instance, bios_property, property_value, bios_password):
-		body = {bios_property: property_value}
-		response = restobj.rest_patch(instance["href"], body, bios_password)
-		restobj.error_handler(response)
-::
+ def setproperty (restobj,instance, bios_property, property_value, bios_password):
+     body = {bios_property: property_value}
+     response = restobj.rest_patch(instance["href"], body, bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the UEFI settings to the new values provided, however the changes will go into effect only after a system reset or reboot.
 

--- a/docs/ex34_set_bios_uefi_shell_startup.rest
+++ b/docs/ex34_set_bios_uefi_shell_startup.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 34: Set BIOS UEFI shell startup settings
 ================================================
 
-The method **ex34_set_bios_uefi_shell_startup** takes an instance of rest object ( or redfish object if using Redfish API ) and BIOS service settings as arguments.
+The method **ex34_set_bios_uefi_shell_startup** takes an instance of rest
+object (or redfish object if using Redfish API) and BIOS service settings as
+arguments.
 
 .. code-block:: python
 
@@ -32,7 +38,8 @@ Find and get the BIOS settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("Bios.")
 
-For the UEFI settings, prepare the request body with only the UEFI settings we want to change and perform the PATCH request.
+For the UEFI settings, prepare the request body with only the UEFI settings we
+want to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -41,6 +48,10 @@ For the UEFI settings, prepare the request body with only the UEFI settings we w
      response = restobj.rest_patch(instance["href"], body, bios_password)
      restobj.error_handler(response)
 
-A successful PATCH response will set the UEFI settings to the new values provided, however the changes will go into effect only after a system reset or reboot.
+A successful PATCH response will set the UEFI settings to the new values
+provided, however the changes will go into effect only after a system reset or
+reboot.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex35_set_bios_iscsi.rest
+++ b/docs/ex35_set_bios_iscsi.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 35: Set BIOS ISCSI
 ==========================
 
-The method **ex35_set_bios_iscsi** takes an instance of rest object ( or redfish object if using Redfish API ) and iSCSI settings as arguments.
+The method **ex35_set_bios_iscsi** takes an instance of rest object (or redfish
+object if using Redfish API) and iSCSI settings as arguments.
 
 .. code-block:: python
 
@@ -32,7 +37,8 @@ Find and get the iSCSI settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("HpiSCSISoftwareInitiator.")
 
-For the iSCSI settings, prepare the request body with only the iSCSI settings we want to change and perform the PATCH request.
+For the iSCSI settings, prepare the request body with only the iSCSI settings
+we want to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -41,6 +47,10 @@ For the iSCSI settings, prepare the request body with only the iSCSI settings we
                                    bios_password)
      restobj.error_handler(response)
 
-A successful PATCH response will set the iSCSI settings to the new values provided, however the changes will go into effect only after a system reset or reboot.
+A successful PATCH response will set the iSCSI settings to the new values
+provided, however the changes will go into effect only after a system reset or
+reboot.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex35_set_bios_iscsi.rest
+++ b/docs/ex35_set_bios_iscsi.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,45 +11,35 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 35: Set BIOS ISCSI
-=============================
+==========================
 
 The method **ex35_set_bios_iscsi** takes an instance of rest object ( or redfish object if using Redfish API ) and iSCSI settings as arguments.
 
 .. code-block:: python
 
-  def ex35_set_bios_iscsi(restobj, bios_properties, bios_password=None):
-
-::
+ def ex35_set_bios_iscsi(restobj, bios_properties, bios_password=None):
 
 Find and get the iSCSI settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("HpiSCSISoftwareInitiator.")
-
-::
+ instances = restobj.search_for_type("HpiSCSISoftwareInitiator.")
 
 For the iSCSI settings, prepare the request body with only the iSCSI settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        response = restobj.rest_patch(instance["href"], bios_properties, \
-                                      bios_password)
-        restobj.error_handler(response)
-::
+ for instance in instances:
+     response = restobj.rest_patch(instance["href"], bios_properties, \
+                                   bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the iSCSI settings to the new values provided, however the changes will go into effect only after a system reset or reboot.
 

--- a/docs/ex36_set_bios_url_boot_file.rest
+++ b/docs/ex36_set_bios_url_boot_file.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 36: Set BIOS URL boot file
 ==================================
 
-The method **ex36_set_bios_url_boot_file** takes an instance of rest object ( or redfish object if using Redfish API ) and a filepath as arguments.
+The method **ex36_set_bios_url_boot_file** takes an instance of rest object (or
+redfish object if using Redfish API) and a filepath as arguments.
 
 .. code-block:: python
 
@@ -32,7 +37,8 @@ Find and get the BIOS settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("Bios.")
 
-For the filepath, prepare the request body with only the UrlBootFile we want to change and perform the PATCH request.
+For the filepath, prepare the request body with only the UrlBootFile we want to
+change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -42,6 +48,9 @@ For the filepath, prepare the request body with only the UrlBootFile we want to 
      response = restobj.rest_patch(instance["href"], body, bios_password)
      restobj.error_handler(response)
 
-A successful PATCH response will set the Boot file to the new values provided, however the changes will go into effect only after a system reset or reboot.
+A successful PATCH response will set the Boot file to the new values provided,
+however the changes will go into effect only after a system reset or reboot.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex36_set_bios_url_boot_file.rest
+++ b/docs/ex36_set_bios_url_boot_file.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,46 +11,36 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 36: Set BIOS URL boot file
-=============================
+==================================
 
 The method **ex36_set_bios_url_boot_file** takes an instance of rest object ( or redfish object if using Redfish API ) and a filepath as arguments.
 
 .. code-block:: python
 
-  def ex36_set_bios_url_boot_file(restobj, path='', bios_password=None):
-
-::
+ def ex36_set_bios_url_boot_file(restobj, path='', bios_password=None):
 
 Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the filepath, prepare the request body with only the UrlBootFile we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        print instance
-        body = {"UrlBootFile": path}
-        response = restobj.rest_patch(instance["href"], body, bios_password)
-        restobj.error_handler(response)
-::
+ for instance in instances:
+     print instance
+     body = {"UrlBootFile": path}
+     response = restobj.rest_patch(instance["href"], body, bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the Boot file to the new values provided, however the changes will go into effect only after a system reset or reboot.
 

--- a/docs/ex37_set_eskm_primarykeyserver.rest
+++ b/docs/ex37_set_eskm_primarykeyserver.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,9 @@ Redfish Object creation:
 Example 37: Set ESKM Primary Key Server
 =======================================
 
-The method **ex37_set_ESKM_PrimaryKeyServer** takes an instance of rest object ( or redfish object if using Redfish API ) and primary key server address and port settings as arguments.
+The method **ex37_set_ESKM_PrimaryKeyServer** takes an instance of rest object
+(or redfish object if using Redfish API) and primary key server address and
+port settings as arguments.
 
 .. code-block:: python
 
@@ -36,7 +42,8 @@ Find and get the ESKM settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("ESKM.")
 
-For the ESKM settings, prepare the request body with the Primary key server settings we want to change and perform the PATCH request.
+For the ESKM settings, prepare the request body with the Primary key server
+settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -49,4 +56,6 @@ For the ESKM settings, prepare the request body with the Primary key server sett
      response = restobj.rest_patch(instance["href"], body)
      restobj.error_handler(response)
 
-A successful PATCH response will set the primary key server settings to the new values provided in ESKM settings, however the changes will go into effect only after a system reset or reboot.
+A successful PATCH response will set the primary key server settings to the new
+values provided in ESKM settings, however the changes will go into effect only
+after a system reset or reboot.

--- a/docs/ex37_set_eskm_primarykeyserver.rest
+++ b/docs/ex37_set_eskm_primarykeyserver.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,49 +14,39 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 37: Set ESKM Primary Key Server
-=============================
+=======================================
 
 The method **ex37_set_ESKM_PrimaryKeyServer** takes an instance of rest object ( or redfish object if using Redfish API ) and primary key server address and port settings as arguments.
 
 .. code-block:: python
 
-  def ex37_set_ESKM_PrimaryKeyServer(restobj, PrimaryKeyServerAddress,\
-                               PrimaryKeyServerPort):
-
-::
+ def ex37_set_ESKM_PrimaryKeyServer(restobj, PrimaryKeyServerAddress,\
+                                    PrimaryKeyServerPort):
 
 Find and get the ESKM settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("ESKM.")
-
-::
+ instances = restobj.search_for_type("ESKM.")
 
 For the ESKM settings, prepare the request body with the Primary key server settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = dict()
+ for instance in instances:
+     body = dict()
 
-        body["PrimaryKeyServerAddress"] = PrimaryKeyServerAddress
-        body["PrimaryKeyServerPort"] = int(PrimaryKeyServerPort)
+     body["PrimaryKeyServerAddress"] = PrimaryKeyServerAddress
+     body["PrimaryKeyServerPort"] = int(PrimaryKeyServerPort)
 
-        response = restobj.rest_patch(instance["href"], body)
-        restobj.error_handler(response)
-::
+     response = restobj.rest_patch(instance["href"], body)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the primary key server settings to the new values provided in ESKM settings, however the changes will go into effect only after a system reset or reboot.

--- a/docs/ex38_set_eskm_username_password.rest
+++ b/docs/ex38_set_eskm_username_password.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,51 +14,41 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 38: Set ESKM username password
-=============================
+======================================
 
 The method **ex38_set_ESKM_username_password** takes an instance of rest object ( or redfish object if using Redfish API ) and a ESKM username, password and account group settings as arguments.
 
 .. code-block:: python
 
-  def ex38_set_ESKM_username_password(restobj, username, password, accountgroup):
-
-::
+ def ex38_set_ESKM_username_password(restobj, username, password, accountgroup):
 
 Find and get the ESKM settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("ESKM.")
-
-::
+ instances = restobj.search_for_type("ESKM.")
 
 For the ESKM settings, prepare the request body with the ESKM settings we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = dict()
+ for instance in instances:
+     body = dict()
 
-        body["KeyManagerConfig"] = dict()
-        body["KeyManagerConfig"]["LoginName"] = username
-        body["KeyManagerConfig"]["Password"] = password
-        body["KeyManagerConfig"]["AccountGroup"] = accountgroup
-        body["KeyManagerConfig"]["ESKMLocalCACertificateName"] = ""
+     body["KeyManagerConfig"] = dict()
+     body["KeyManagerConfig"]["LoginName"] = username
+     body["KeyManagerConfig"]["Password"] = password
+     body["KeyManagerConfig"]["AccountGroup"] = accountgroup
+     body["KeyManagerConfig"]["ESKMLocalCACertificateName"] = ""
 
-        response = restobj.rest_patch(instance["href"], body)
-        restobj.error_handler(response)
-::
+     response = restobj.rest_patch(instance["href"], body)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the ESKM settings to the new values provided in ESKM settings, however the changes will go into effect only after a system reset or reboot.

--- a/docs/ex38_set_eskm_username_password.rest
+++ b/docs/ex38_set_eskm_username_password.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,9 @@ Redfish Object creation:
 Example 38: Set ESKM username password
 ======================================
 
-The method **ex38_set_ESKM_username_password** takes an instance of rest object ( or redfish object if using Redfish API ) and a ESKM username, password and account group settings as arguments.
+The method **ex38_set_ESKM_username_password** takes an instance of rest object
+(or redfish object if using Redfish API) and a ESKM username, password and
+account group settings as arguments.
 
 .. code-block:: python
 
@@ -35,7 +41,8 @@ Find and get the ESKM settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("ESKM.")
 
-For the ESKM settings, prepare the request body with the ESKM settings we want to change and perform the PATCH request.
+For the ESKM settings, prepare the request body with the ESKM settings we want
+to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -51,4 +58,6 @@ For the ESKM settings, prepare the request body with the ESKM settings we want t
      response = restobj.rest_patch(instance["href"], body)
      restobj.error_handler(response)
 
-A successful PATCH response will set the ESKM settings to the new values provided in ESKM settings, however the changes will go into effect only after a system reset or reboot.
+A successful PATCH response will set the ESKM settings to the new values
+provided in ESKM settings, however the changes will go into effect only after a
+system reset or reboot.

--- a/docs/ex39_test_eskm_connection.rest
+++ b/docs/ex39_test_eskm_connection.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 39: test ESKM conenction
 ================================
 
-The method **ex39_set_ESKM_username_password** takes an instance of rest object ( or redfish object if using Redfish API ) as arguments.
+The method **ex39_set_ESKM_username_password** takes an instance of rest object
+(or redfish object if using Redfish API) as arguments.
 
 .. code-block:: python
 
@@ -50,4 +55,6 @@ Send HTTP POST request to the system URI(s) using the prepared request body.
  response = restobj.rest_post(instance["href"], body)
  restobj.error_handler(response)
 
-A successful POST response will set the ESKM settings "TestESKMConnection" and return a success code, however the changes will go into effect only after a system reset or reboot.
+A successful POST response will set the ESKM settings "TestESKMConnection" and
+return a success code, however the changes will go into effect only after a
+system reset or reboot.

--- a/docs/ex39_test_eskm_connection.rest
+++ b/docs/ex39_test_eskm_connection.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,52 +14,40 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 39: test ESKM conenction
-=============================
+================================
 
 The method **ex39_set_ESKM_username_password** takes an instance of rest object ( or redfish object if using Redfish API ) as arguments.
 
 .. code-block:: python
 
-  def ex39_test_ESKM_connection(restobj):
-
-::
+ def ex39_test_ESKM_connection(restobj):
 
 Find and get the ESKM settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("ESKM.")
-
-::
+ instances = restobj.search_for_type("ESKM.")
 
 Prepare the request body with TestESKMConnections.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = dict()
-        body["Action"] = "TestESKMConnections"
-::
+ for instance in instances:
+     body = dict()
+     body["Action"] = "TestESKMConnections"
 
 Send HTTP POST request to the system URI(s) using the prepared request body.
 
 .. code-block:: python
 
-    response = restobj.rest_post(instance["href"], body)
-    restobj.error_handler(response)
-
-::
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)
 
 A successful POST response will set the ESKM settings "TestESKMConnection" and return a success code, however the changes will go into effect only after a system reset or reboot.

--- a/docs/ex3_change_bios_setting.rest
+++ b/docs/ex3_change_bios_setting.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,9 +27,13 @@ Redfish Object creation:
 Example 3: Change BIOS setting
 ==============================
 
-This is an example from RestfulApiExamples.py that can be used to change system BIOS settings. The example in RedfishApiExamples.py  is similar except that a rest object is replaced by a redfish object.
+This is an example from RestfulApiExamples.py that can be used to change system
+BIOS settings. The example in RedfishApiExamples.py is similar except that a
+rest object is replaced by a redfish object.
 
-The method **ex3_change_bios_setting** takes an instance of rest object, BIOS property of interest, the new value for the BIOS property and BIOS password as arguments.
+The method **ex3_change_bios_setting** takes an instance of rest object, BIOS
+property of interest, the new value for the BIOS property and BIOS password as
+arguments.
 
 .. code-block:: python
 
@@ -38,7 +46,8 @@ Find and get the BIOS settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("Bios.")
 
-For the BIOS settings URI/s prepare the request body with only the BIOS property we want to change and perform the PATCH request.
+For the BIOS settings URI/s prepare the request body with only the BIOS
+property we want to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -48,6 +57,10 @@ For the BIOS settings URI/s prepare the request body with only the BIOS property
                                    optionalpassword=bios_password)
      restobj.error_handler(response)
 
-A successful PATCH response will set the BIOS property value to the new value provided in BIOS settings, however the BIOS setting changes will get affected only after a system reset or reboot.
+A successful PATCH response will set the BIOS property value to the new value
+provided in BIOS settings, however the BIOS setting changes will get affected
+only after a system reset or reboot.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex3_change_bios_setting.rest
+++ b/docs/ex3_change_bios_setting.rest
@@ -1,11 +1,10 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -15,15 +14,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 3: Change BIOS setting
 ==============================
@@ -34,34 +29,24 @@ The method **ex3_change_bios_setting** takes an instance of rest object, BIOS pr
 
 .. code-block:: python
 
+ def ex3_change_bios_setting(restobj, bios_property, property_value, login_password,
+                             bios_password):
 
-  def ex3_change_bios_setting(restobj, bios_property, property_value, login_password,
-                              bios_password):
-
-::
-
-Find and get the BIOS settings URI from the systems resources collection. 
+Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the BIOS settings URI/s prepare the request body with only the BIOS property we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-        for instance in instances:
-           body = {bios_property: property_value}
-           response = restobj.rest_patch(instance["href"], body, \
-                                            optionalpassword=bios_password)
-           restobj.error_handler(response)
-
-::
-
-
+ for instance in instances:
+     body = {bios_property: property_value}
+     response = restobj.rest_patch(instance["href"], body, \
+                                   optionalpassword=bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the BIOS property value to the new value provided in BIOS settings, however the BIOS setting changes will get affected only after a system reset or reboot.
 

--- a/docs/ex40_reset_eskm_eventlog.rest
+++ b/docs/ex40_reset_eskm_eventlog.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,53 +14,40 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 40: reset ESKM event log
-=============================
+================================
 
 The method **ex40_reset_ESKM_eventlog** takes an instance of rest object ( or redfish object if using Redfish API ) as arguments.
 
 .. code-block:: python
 
-  def ex40_reset_ESKM_eventlog(restobj):
-
-::
+ def ex40_reset_ESKM_eventlog(restobj):
 
 Find and get the ESKM settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("ESKM.")
-
-::
+ instances = restobj.search_for_type("ESKM.")
 
 Prepare the request body with ClearESKMLog.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = dict()
-        body["Action"] = "ClearESKMLog"
-
-::
+ for instance in instances:
+     body = dict()
+     body["Action"] = "ClearESKMLog"
 
 Send HTTP POST request to the system URI(s) using the prepared request body.
 
 .. code-block:: python
 
-    response = restobj.rest_post(instance["href"], body)
-    restobj.error_handler(response)
-
-::
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)
 
 A successful POST response will set the ESKM action to "ClearESKMLog" and return a success code, however the changes will go into effect only after a system reset or reboot.

--- a/docs/ex40_reset_eskm_eventlog.rest
+++ b/docs/ex40_reset_eskm_eventlog.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 40: reset ESKM event log
 ================================
 
-The method **ex40_reset_ESKM_eventlog** takes an instance of rest object ( or redfish object if using Redfish API ) as arguments.
+The method **ex40_reset_ESKM_eventlog** takes an instance of rest object (or
+redfish object if using Redfish API) as arguments.
 
 .. code-block:: python
 
@@ -50,4 +55,6 @@ Send HTTP POST request to the system URI(s) using the prepared request body.
  response = restobj.rest_post(instance["href"], body)
  restobj.error_handler(response)
 
-A successful POST response will set the ESKM action to "ClearESKMLog" and return a success code, however the changes will go into effect only after a system reset or reboot.
+A successful POST response will set the ESKM action to "ClearESKMLog" and
+return a success code, however the changes will go into effect only after a
+system reset or reboot.

--- a/docs/ex41_dump_eskm_eventlog.rest
+++ b/docs/ex41_dump_eskm_eventlog.rest
@@ -1,12 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -15,49 +14,36 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 41: Dump ESKM Event Log
-==========================================
+===============================
 
 The method **def ex41_dump_eskm_event_log** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
 .. code-block:: python
 
-
-  def ex41_dump_eskm_event_log(restobj):
-
-::
-
+ def ex41_dump_eskm_event_log(restobj):
 
 Find and get the SecurityService URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("SecurityService.")
-
-::
+ instances = restobj.search_for_type("SecurityService.")
 
 Send HTTP GET request to log ESKM URI(s).
 
 .. code-block:: python
 
-    for instance in instances:
-        tmp = restobj.rest_get(instance["href"])
-        response = restobj.rest_get(tmp.dict["links"]["ESKM"]["href"])
-        for entry in response.dict["ESKMEvents"]:
-            sys.stdout.write(entry["Timestamp"] + "\n" \
-                             + entry["Event"] + "\n")
-
-::
+ for instance in instances:
+     tmp = restobj.rest_get(instance["href"])
+     response = restobj.rest_get(tmp.dict["links"]["ESKM"]["href"])
+     for entry in response.dict["ESKMEvents"]:
+         sys.stdout.write(entry["Timestamp"] + "\n" \
+                                + entry["Event"] + "\n")
 
 A successful GET response fetch ESKM Events along with a timestamp.

--- a/docs/ex41_dump_eskm_eventlog.rest
+++ b/docs/ex41_dump_eskm_eventlog.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 41: Dump ESKM Event Log
 ===============================
 
-The method **def ex41_dump_eskm_event_log** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **def ex41_dump_eskm_event_log** takes an instance of rest object
+(or redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex42_get_eskm.rest
+++ b/docs/ex42_get_eskm.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,94 +14,76 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 42: Get ESKM
-================================
+====================
 
 The method **ex42_get_ESKM** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ def ex42_get_ESKM(restobj):
+
+Find and get the system resource for SecurityService.
 
 .. code-block:: python
 
-
-    def ex42_get_ESKM(restobj):
-
-::
-
-
-Find and get the system resource for SecurityService. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("SecurityService.")
-
-::
+ instances = restobj.search_for_type("SecurityService.")
 
 Send HTTP GET request to the system URI(s) in links ESKM.
 
 .. code-block:: python
 
-  for instance in instances:
-      tmp = restobj.rest_get(instance["href"])
-      response = restobj.rest_get(tmp.dict["links"]["ESKM"]["href"])
-
-::
+ for instance in instances:
+     tmp = restobj.rest_get(instance["href"])
+     response = restobj.rest_get(tmp.dict["links"]["ESKM"]["href"])
 
 For each system print address port, redundancy requirement, account group, certificate name and certificate issuer from the response body.
 
 .. code-block:: python
 
-        sys.stdout.write("\tPrimaryKeyServerAddress:  " +
-                         json.dumps(response.dict["PrimaryKeyServerAddress"])\
-                         + "\n")
-        sys.stdout.write("\tPrimaryKeyServerPort:  " +
-                         json.dumps(response.dict["PrimaryKeyServerPort"])\
-                         + "\n")
-        sys.stdout.write("\tSecondaryKeyServerAddress:  " +
-                         json.dumps(response.dict["SecondaryKeyServerAddress"])\
-                          + "\n")
-        sys.stdout.write("\tSecondaryKeyServerPort:  " +
-                         json.dumps(response.dict["SecondaryKeyServerPort"])\
-                          + "\n")
-        sys.stdout.write("\tType:  " +
-                         json.dumps(response.dict["Type"]) + "\n")
-        sys.stdout.write("\tKeyServerRedundancyReq:  " +
-                         json.dumps(response.dict["KeyServerRedundancyReq"])\
-                          + "\n")
+ sys.stdout.write("\tPrimaryKeyServerAddress:  " +
+                  json.dumps(response.dict["PrimaryKeyServerAddress"])\
+                  + "\n")
+ sys.stdout.write("\tPrimaryKeyServerPort:  " +
+                  json.dumps(response.dict["PrimaryKeyServerPort"])\
+                  + "\n")
+ sys.stdout.write("\tSecondaryKeyServerAddress:  " +
+                  json.dumps(response.dict["SecondaryKeyServerAddress"])\
+                   + "\n")
+ sys.stdout.write("\tSecondaryKeyServerPort:  " +
+                  json.dumps(response.dict["SecondaryKeyServerPort"])\
+                   + "\n")
+ sys.stdout.write("\tType:  " +
+                  json.dumps(response.dict["Type"]) + "\n")
+ sys.stdout.write("\tKeyServerRedundancyReq:  " +
+                  json.dumps(response.dict["KeyServerRedundancyReq"])\
+                   + "\n")
 
-        sys.stdout.write("\tAccountGroup:  " +
-                         json.dumps(response.dict["KeyManagerConfig"]\
-                                    ["AccountGroup"]) + "\n")
-        sys.stdout.write("\tESKMLocalCACertificateName:  " +
-                         json.dumps(response.dict["KeyManagerConfig"]\
-                                    ["ESKMLocalCACertificateName"]) + "\n")
-        sys.stdout.write("\tImportedCertificateIssuer:  " +
-                         json.dumps(response.dict["KeyManagerConfig"]\
-                                    ["ImportedCertificateIssuer"]) + "\n")
-::
+ sys.stdout.write("\tAccountGroup:  " +
+                  json.dumps(response.dict["KeyManagerConfig"]\
+                  ["AccountGroup"]) + "\n")
+ sys.stdout.write("\tESKMLocalCACertificateName:  " +
+                  json.dumps(response.dict["KeyManagerConfig"]\
+                  ["ESKMLocalCACertificateName"]) + "\n")
+ sys.stdout.write("\tImportedCertificateIssuer:  " +
+                  json.dumps(response.dict["KeyManagerConfig"]\
+                  ["ImportedCertificateIssuer"]) + "\n")
 
 Next print a log of ESKM events if any.
 
 .. code-block:: python
 
-        sys.stdout.write("\tESKMEvents:  " +
-                         json.dumps(response.dict["ESKMEvents"]) + "\n")
+ sys.stdout.write("\tESKMEvents:  " +
+                  json.dumps(response.dict["ESKMEvents"]) + "\n")
 
-        tmp = response.dict["ESKMEvents"]
-        for entry in tmp:
-            sys.stdout.write("\tTimestamp : " + entry["Timestamp"] +\
-                              "Event:  " +
-                             json.dumps(entry["Event"]) + "\n")
-
-::
+ tmp = response.dict["ESKMEvents"]
+ for entry in tmp:
+     sys.stdout.write("\tTimestamp : " + entry["Timestamp"] +\
+                      "Event:  " +
+                      json.dumps(entry["Event"]) + "\n")

--- a/docs/ex42_get_eskm.rest
+++ b/docs/ex42_get_eskm.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 42: Get ESKM
 ====================
 
-The method **ex42_get_ESKM** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex42_get_ESKM** takes an instance of rest object (or redfish
+object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -43,7 +48,8 @@ Send HTTP GET request to the system URI(s) in links ESKM.
      tmp = restobj.rest_get(instance["href"])
      response = restobj.rest_get(tmp.dict["links"]["ESKM"]["href"])
 
-For each system print address port, redundancy requirement, account group, certificate name and certificate issuer from the response body.
+For each system print address port, redundancy requirement, account group,
+certificate name and certificate issuer from the response body.
 
 .. code-block:: python
 

--- a/docs/ex43_get_encryptionsettings.rest
+++ b/docs/ex43_get_encryptionsettings.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,71 +14,54 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 43: Get Encryption Settings
-================================
+===================================
 
 The method **ex43_get_EncryptionSettings** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ ex43_get_EncryptionSettings(restobj):
+
+Find and get the system resource for HpSmartStorageArrayController.
 
 .. code-block:: python
 
-
-    ex43_get_EncryptionSettings(restobj):
-
-::
-
-
-Find and get the system resource for HpSmartStorageArrayController. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("HpSmartStorageArrayController.")
-
-::
+ instances = restobj.search_for_type("HpSmartStorageArrayController.")
 
 Place the list of Encryption settings into a list.
 
 .. code-block:: python
 
-    types = ["Name","Model","SerialNumber","EncryptionBootPasswordSet",\
-             "EncryptionCryptoOfficerPasswordSet",\
-             "EncryptionLocalKeyCacheEnabled","EncryptionMixedVolumesEnabled",\
-             "EncryptionPhysicalDriveCount","EncryptionRecoveryParamsSet",\
-             "EncryptionStandaloneModeEnabled","EncryptionUserPasswordSet"]
-::
+ types = ["Name","Model","SerialNumber","EncryptionBootPasswordSet",\
+          "EncryptionCryptoOfficerPasswordSet",\
+          "EncryptionLocalKeyCacheEnabled","EncryptionMixedVolumesEnabled",\
+          "EncryptionPhysicalDriveCount","EncryptionRecoveryParamsSet",\
+          "EncryptionStandaloneModeEnabled","EncryptionUserPasswordSet"]
 
 Send HTTP GET request to the system URI(s).
 
 .. code-block:: python
 
-  for instance in instances:
-        response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 For each system print encryption settings from the response body.
 
 .. code-block:: python
 
-    for item in types:
-        sys.stdout.write("\tID:  " +
-                         str(response.dict["@odata.id"]) + "\n")
-        if item in response.dict:
-            sys.stdout.write("\t" + item +
-                             str(response.dict[item]) + "\n")
-        else:
-            sys.stderr.write("\t" + item + "is not " \
-                    "available on HpSmartStorageArrayController resource\n")
-::
+ for item in types:
+     sys.stdout.write("\tID:  " +
+                      str(response.dict["@odata.id"]) + "\n")
+     if item in response.dict:
+         sys.stdout.write("\t" + item +
+                          str(response.dict[item]) + "\n")
+     else:
+         sys.stderr.write("\t" + item + "is not " \
+                          "available on HpSmartStorageArrayController resource\n")

--- a/docs/ex43_get_encryptionsettings.rest
+++ b/docs/ex43_get_encryptionsettings.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 43: Get Encryption Settings
 ===================================
 
-The method **ex43_get_EncryptionSettings** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex43_get_EncryptionSettings** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 

--- a/docs/ex44_get_logicaldrives.rest
+++ b/docs/ex44_get_logicaldrives.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 44: Get logical drives
 ==============================
 
-The method **ex44_get_LogicalDrives** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex44_get_LogicalDrives** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -42,7 +47,8 @@ Send HTTP GET request to the system URI(s).
  for instance in instances:
      response = restobj.rest_get(instance["href"])
 
-For each system print array controllers from the response body. Return an error if not available.
+For each system print array controllers from the response body. Return an error
+if not available.
 
 .. code-block:: python
 

--- a/docs/ex44_get_logicaldrives.rest
+++ b/docs/ex44_get_logicaldrives.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,58 +14,41 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 44: Get logical drives
-================================
+==============================
 
 The method **ex44_get_LogicalDrives** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ def ex44_get_LogicalDrives(restobj):
+
+Find and get the system resource for HpSmartStorageArrayController.
 
 .. code-block:: python
 
-
-    def ex44_get_LogicalDrives(restobj):
-
-::
-
-
-Find and get the system resource for HpSmartStorageArrayController. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("HpSmartStorageArrayController.")
-
-::
+ instances = restobj.search_for_type("HpSmartStorageArrayController.")
 
 Send HTTP GET request to the system URI(s).
 
 .. code-block:: python
 
-    for instance in instances:
-        response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 For each system print array controllers from the response body. Return an error if not available.
 
 .. code-block:: python
 
-        if "ArrayControllers" in response.dict:
-            sys.stdout.write("\tArrayControllers:  " +
-                           str(response.dict["ArrayControllers"]) + "\n")
-        else:
-            sys.stderr.write("\tArrayControllers is not " \
-                        "available on HpSmartStorageArrayController resource\n")
-::
-
+ if "ArrayControllers" in response.dict:
+     sys.stdout.write("\tArrayControllers:  " +
+                      str(response.dict["ArrayControllers"]) + "\n")
+ else:
+     sys.stderr.write("\tArrayControllers is not " \
+                      "available on HpSmartStorageArrayController resource\n")

--- a/docs/ex45_get_license_key.rest
+++ b/docs/ex45_get_license_key.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 45: Get license key
 ===========================
 
-The method **ex45_get_license_key** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
+The method **ex45_get_license_key** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -35,7 +40,8 @@ Find and get the system resource for HpSmartStorageArrayController.
 
  instances = restobj.search_for_type("HpiLOLicense.")
 
-Create a dictionary to hold license results. Create a list of license properties.
+Create a dictionary to hold license results. Create a list of license
+properties.
 
 .. code-block:: python
 
@@ -49,7 +55,8 @@ Send HTTP GET request to the system URI(s).
  for instance in instances:
      response = restobj.rest_get(instance["href"])
 
-For each license property, check the license property from the response body. Then print the value.
+For each license property, check the license property from the response body.
+Then print the value.
 
 .. code-block:: python
 

--- a/docs/ex45_get_license_key.rest
+++ b/docs/ex45_get_license_key.rest
@@ -1,11 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -14,64 +14,45 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 45: Get license key
-================================
+===========================
 
 The method **ex45_get_license_key** takes an instance of rest object ( or redfish object if using Redfish API ) as argument.
 
+.. code-block:: python
+
+ def ex45_get_license_key(restobj):
+
+Find and get the system resource for HpSmartStorageArrayController.
 
 .. code-block:: python
 
-
-    def ex45_get_license_key(restobj):
-
-::
-
-
-Find and get the system resource for HpSmartStorageArrayController. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("HpiLOLicense.")
-
-::
+ instances = restobj.search_for_type("HpiLOLicense.")
 
 Create a dictionary to hold license results. Create a list of license properties.
 
 .. code-block:: python
 
-    license_result = dict()
-    licenseproperties = ["License", "LicenseKey", "LicenseType"]
-
-::
+ license_result = dict()
+ licenseproperties = ["License", "LicenseKey", "LicenseType"]
 
 Send HTTP GET request to the system URI(s).
 
 .. code-block:: python
 
-    for instance in instances:
-        response = restobj.rest_get(instance["href"])
-
-::
+ for instance in instances:
+     response = restobj.rest_get(instance["href"])
 
 For each license property, check the license property from the response body. Then print the value.
 
 .. code-block:: python
 
-        for licenseproperty in licenseproperties:
-            sys.stdout.write("\t" + licenseproperty + ": " + \
-                              str(response.dict[licenseproperty]) + "\n")
-
-::
+ for licenseproperty in licenseproperties:
+     sys.stdout.write("\t" + licenseproperty + ": " + \
+                       str(response.dict[licenseproperty]) + "\n")

--- a/docs/ex46_get_ahs_data.rest
+++ b/docs/ex46_get_ahs_data.rest
@@ -1,12 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
- 
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -15,61 +14,47 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 46: Get AHS data
-======================
+========================
 
 The method **ex46_get_ahs_data** takes an instance of rest object ( or redfish object if using Redfish API ) as an argument.
 
 .. code-block:: python
 
-  def ex46_get_ahs_data(restobj):
+ def ex46_get_ahs_data(restobj):
 
-::
-
-Send HTTP GET request to manager URI '/rest/v1/Manager'.  
+Send HTTP GET request to manager URI '/rest/v1/Manager'.
 
 .. code-block:: python
 
-
-     response = restobj.rest_get("/rest/v1/Manager.")
-::
-
-
+ response = restobj.rest_get("/rest/v1/Manager.")
 
 From the response body find the ActiveHealthSystem URI.
 
 .. code-block:: python
 
-    for instance in instances:
-        tmp = restobj.rest_get(instance["href"])
-        response = restobj.rest_get(tmp.dict["Oem"]["Hp"]["links"]\
-                                    ["ActiveHealthSystem"]["href"])
-::
+ for instance in instances:
+    tmp = restobj.rest_get(instance["href"])
+    response = restobj.rest_get(tmp.dict["Oem"]["Hp"]["links"]\
+                                        ["ActiveHealthSystem"]["href"])
 
 Get the extref link for download through GET request.
 
 .. code-block:: python
 
-    ahslink = restobj.rest_get(response.dict["links"]["AHSLocation"]\
-                                   ["extref"])
-::
+ ahslink = restobj.rest_get(response.dict["links"]["AHSLocation"]\
+                                         ["extref"])
 
 Create and write to a binary file.
 
 .. code-block:: python
 
-        with open("data.ahs", 'wb') as ahsoutput:
-            ahsoutput.write(ahslink.read)
-            ahsoutput.close()
-
-::
+ with open("data.ahs", 'wb') as ahsoutput:
+     ahsoutput.write(ahslink.read)
+     ahsoutput.close()

--- a/docs/ex46_get_ahs_data.rest
+++ b/docs/ex46_get_ahs_data.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 46: Get AHS data
 ========================
 
-The method **ex46_get_ahs_data** takes an instance of rest object ( or redfish object if using Redfish API ) as an argument.
+The method **ex46_get_ahs_data** takes an instance of rest object (or redfish
+object if using Redfish API) as an argument.
 
 .. code-block:: python
 

--- a/docs/ex47_clear_ahs_data.rest
+++ b/docs/ex47_clear_ahs_data.rest
@@ -6,7 +6,11 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -23,7 +27,8 @@ Redfish Object creation:
 Example 47: Clear AHS data
 ==========================
 
-The method **ex47_clear_ahs_data** takes an instance of rest object ( or redfish object if using Redfish API ) as an argument.
+The method **ex47_clear_ahs_data** takes an instance of rest object (or redfish
+object if using Redfish API) as an argument.
 
 .. code-block:: python
 
@@ -35,7 +40,8 @@ Search for Manager URI type.
 
  instances = restobj.search_for_type("Manager.")
 
-Set body to the ClearLog action, then set the response to the ActiveHealthSystem URI.
+Set body to the ClearLog action, then set the response to the
+ActiveHealthSystem URI.
 
 .. code-block:: python
 

--- a/docs/ex47_clear_ahs_data.rest
+++ b/docs/ex47_clear_ahs_data.rest
@@ -1,12 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
- 
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -15,44 +14,33 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
 Example 47: Clear AHS data
-======================
+==========================
 
 The method **ex47_clear_ahs_data** takes an instance of rest object ( or redfish object if using Redfish API ) as an argument.
 
 .. code-block:: python
 
-  def ex47_clear_ahs_data(restobj):
-
-::
+ def ex47_clear_ahs_data(restobj):
 
 Search for Manager URI type.
 
 .. code-block:: python
 
-
-    instances = restobj.search_for_type("Manager.")
-::
-
-
+ instances = restobj.search_for_type("Manager.")
 
 Set body to the ClearLog action, then set the response to the ActiveHealthSystem URI.
 
 .. code-block:: python
 
-    for instance in instances:
-        tmp = restobj.rest_get(instance["href"])
-        body = {"Action": "ClearLog"}
-        response = restobj.rest_get(tmp.dict["Oem"]["Hp"]["links"]\
-                                    ["ActiveHealthSystem"]["href"], body)
-::
+ for instance in instances:
+     tmp = restobj.rest_get(instance["href"])
+     body = {"Action": "ClearLog"}
+     response = restobj.rest_get(tmp.dict["Oem"]["Hp"]["links"]\
+                                         ["ActiveHealthSystem"]["href"], body)

--- a/docs/ex48_set_bios_password.rest
+++ b/docs/ex48_set_bios_password.rest
@@ -6,7 +6,12 @@
 .. toctree::
    :maxdepth: 1
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx", "https://box1.america.corp.net" both work!), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx",
+"https://box1.america.corp.net" both work!), iLO login username and password as
+arguments. The class also initializes a login session, gets systems resources
+and message registries.
 
 Rest Object creation:
 
@@ -23,7 +28,9 @@ Redfish Object creation:
 Example 48: Set BIOS password
 =============================
 
-The method **ex48_set_bios_password** takes an instance of rest object, bios property of interest, the new value for the bios property and bios password as arguments.
+The method **ex48_set_bios_password** takes an instance of rest object, bios
+property of interest, the new value for the bios property and bios password as
+arguments.
 
 .. code-block:: python
 
@@ -35,7 +42,8 @@ Find and get the BIOS settings URI from the systems resources collection.
 
  instances = restobj.search_for_type("Bios.")
 
-For the BIOS settings URI/s prepare the request body with the password we want to change and perform the PATCH request.
+For the BIOS settings URI/s prepare the request body with the password we want
+to change and perform the PATCH request.
 
 .. code-block:: python
 
@@ -46,6 +54,12 @@ For the BIOS settings URI/s prepare the request body with the password we want t
                                    bios_password)
      restobj.error_handler(response)
 
-A successful PATCH response will set the BIOS password with the new BIOS password, however the BIOS setting changes will get affected only after a system reset or reboot. Additionally, bios_password is a required parameter in this case, since both the new and old password must be supplied for this command to work.
+A successful PATCH response will set the BIOS password with the new BIOS
+password, however the BIOS setting changes will get affected only after a
+system reset or reboot. Additionally, bios_password is a required parameter in
+this case, since both the new and old password must be supplied for this
+command to work.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex48_set_bios_password.rest
+++ b/docs/ex48_set_bios_password.rest
@@ -1,12 +1,11 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
 
 .. toctree::
    :maxdepth: 1
-   
- 
+
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx", "https://box1.america.corp.net" both work!), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
 Rest Object creation:
@@ -15,51 +14,37 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_url, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_url, login_account, login_password)
 
-::
-
 Example 48: Set BIOS password
-==============================
+=============================
 
 The method **ex48_set_bios_password** takes an instance of rest object, bios property of interest, the new value for the bios property and bios password as arguments.
 
 .. code-block:: python
 
+ def ex48_set_bios_password(restobj, new_password, bios_password):
 
-  def ex48_set_bios_password(restobj, new_password, bios_password):
-
-::
-
-Find and get the BIOS settings URI from the systems resources collection. 
+Find and get the BIOS settings URI from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
+ instances = restobj.search_for_type("Bios.")
 
 For the BIOS settings URI/s prepare the request body with the password we want to change and perform the PATCH request.
 
 .. code-block:: python
 
-        for instance in instances:
-            body = {"AdminPassword": new_password, \
-                "OldAdminPassword": bios_password}
-            response = restobj.rest_patch(instance["href"], body, \
-                                      bios_password)
-            restobj.error_handler(response)
-
-::
-
-
+ for instance in instances:
+     body = {"AdminPassword": new_password, \
+             "OldAdminPassword": bios_password}
+     response = restobj.rest_patch(instance["href"], body, \
+                                   bios_password)
+     restobj.error_handler(response)
 
 A successful PATCH response will set the BIOS password with the new BIOS password, however the BIOS setting changes will get affected only after a system reset or reboot. Additionally, bios_password is a required parameter in this case, since both the new and old password must be supplied for this command to work.
 

--- a/docs/ex4_reset_server.rest
+++ b/docs/ex4_reset_server.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,63 +11,41 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
-
 Example 4: Reset a server
 =========================
 
-The method **ex4_reset_server** takes an instance of rest object (or redfish object if using redfish API) and BIOS  password (default None) as arguments.
-
-
-.. code-block:: python
-
-
-    def ex4_reset_server(restobj, bios_password=None):
-
-
-::
-
-
-Find and get the Computer System settings URI from the systems resources collection. 
+The method **ex4_reset_server** takes an instance of rest object (or redfish object if using redfish API) and BIOS password (default None) as arguments.
 
 .. code-block:: python
 
+ def ex4_reset_server(restobj, bios_password=None):
 
-     instances = restobj.search_for_type("ComputerSystem.")
+Find and get the Computer System settings URI from the systems resources collection.
 
-::
+.. code-block:: python
 
+ instances = restobj.search_for_type("ComputerSystem.")
 
 Next the HTTP request body is set for the reset of each Computer System URI.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = dict()
-        body["Action"] = "Reset"
-        body["ResetType"] = "ForceRestart"
-::
+ for instance in instances:
+     body = dict()
+     body["Action"] = "Reset"
+     body["ResetType"] = "ForceRestart"
 
 POST request is sent next and response error is handled if any.
 
 .. code-block:: python
 
-        response = restobj.rest_post(instance["href"], body)
-        restobj.error_handler(response)
-
-::
-
-
-
+ response = restobj.rest_post(instance["href"], body)
+ restobj.error_handler(response)
 
 A successful PATCH response will restart the system.

--- a/docs/ex4_reset_server.rest
+++ b/docs/ex4_reset_server.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,13 +24,15 @@ Redfish Object creation:
 Example 4: Reset a server
 =========================
 
-The method **ex4_reset_server** takes an instance of rest object (or redfish object if using redfish API) and BIOS password (default None) as arguments.
+The method **ex4_reset_server** takes an instance of rest object (or redfish
+object if using redfish API) and BIOS password (default None) as arguments.
 
 .. code-block:: python
 
  def ex4_reset_server(restobj, bios_password=None):
 
-Find and get the Computer System settings URI from the systems resources collection.
+Find and get the Computer System settings URI from the systems resources
+collection.
 
 .. code-block:: python
 

--- a/docs/ex5_enable_secure_boot.rest
+++ b/docs/ex5_enable_secure_boot.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,15 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
 
 Example 5: Enable secured boot
 ==============================
@@ -29,46 +24,26 @@ The method **ex5_enable_secure_boot** takes an instance of rest object (or redfi
 
 .. code-block:: python
 
-  def ex5_enable_secure_boot(restobj, secure_boot_enable, bios_password=None):
+ def ex5_enable_secure_boot(restobj, secure_boot_enable, bios_password=None):
 
-::
-
-Find and get the Secure Boot  URI(s) from the systems resources collection. 
+Find and get the Secure Boot  URI(s) from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("SecureBoot.")
-
-::
-
+ instances = restobj.search_for_type("SecureBoot.")
 
 Prepare the HTTP request body with the boolean value of secure boot enable parameter.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = {"SecureBootEnable": secure_boot_enable}
-
-::
+ for instance in instances:
+     body = {"SecureBootEnable": secure_boot_enable}
 
 PATCH request is sent next to the secure boot URI and response error is handled if any.
 
 .. code-block:: python
 
-       response = restobj.rest_patch(instance["href"], body, \
-                                            optionalpassword=bios_password)
-       restobj.error_handler(response)
+ response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
+ restobj.error_handler(response)
 
-::
-
-  
-A successful PATCH response implies that Secure Boot is set, however the  changes will get affected only after a system reset or reboot.
-
-
-  
-
-
-
-  
-
+A successful PATCH response implies that Secure Boot is set, however the changes will get affected only after a system reset or reboot.

--- a/docs/ex5_enable_secure_boot.rest
+++ b/docs/ex5_enable_secure_boot.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 5: Enable secured boot
 ==============================
 
-The method **ex5_enable_secure_boot** takes an instance of rest object (or redfish object if using Redfish API), boolean secure boot enable value and BIOS password (default None).
+The method **ex5_enable_secure_boot** takes an instance of rest object (or
+redfish object if using Redfish API), boolean secure boot enable value and BIOS
+password (default None).
 
 .. code-block:: python
 
@@ -32,18 +38,21 @@ Find and get the Secure Boot  URI(s) from the systems resources collection.
 
  instances = restobj.search_for_type("SecureBoot.")
 
-Prepare the HTTP request body with the boolean value of secure boot enable parameter.
+Prepare the HTTP request body with the boolean value of secure boot enable
+parameter.
 
 .. code-block:: python
 
  for instance in instances:
      body = {"SecureBootEnable": secure_boot_enable}
 
-PATCH request is sent next to the secure boot URI and response error is handled if any.
+PATCH request is sent next to the secure boot URI and response error is handled
+if any.
 
 .. code-block:: python
 
  response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
  restobj.error_handler(response)
 
-A successful PATCH response implies that Secure Boot is set, however the changes will get affected only after a system reset or reboot.
+A successful PATCH response implies that Secure Boot is set, however the
+changes will get affected only after a system reset or reboot.

--- a/docs/ex6_bios_revert_default.rest
+++ b/docs/ex6_bios_revert_default.rest
@@ -1,9 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -13,17 +11,11 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
-
-::
-
-
 
 Example 6: Revert to default BIOS setting
 =========================================
@@ -32,41 +24,27 @@ The method **ex6_bios_revert_default** takes an instance of rest object (or redf
 
 .. code-block:: python
 
+ def ex6_bios_revert_default(restobj):
 
-    def ex6_bios_revert_default(restobj):
-
-
-::
-
-
-Find and get the BIOS settings URI(s) from the systems resources collection. 
+Find and get the BIOS settings URI(s) from the systems resources collection.
 
 .. code-block:: python
 
-
-     instances = restobj.search_for_type("Bios.")
-
-::
-
+ instances = restobj.search_for_type("Bios.")
 
 Next the HTTP request body is set with default configuration.
 
 .. code-block:: python
 
-    for instance in instances:
-        body = {"BaseConfig": "default"}
-::
+ for instance in instances:
+     body = {"BaseConfig": "default"}
 
 PUT request is performed next and response error is handled if any.
 
 .. code-block:: python
 
-        response = restobj.rest_put(instance["href"], body)
-        restobj.error_handler(response)
-
-::
-
-
+ response = restobj.rest_put(instance["href"], body)
+ restobj.error_handler(response)
 
 A successful PUT response implies that BIOS is set to default settings, however the changes will get affected only after a system reset or reboot.
 

--- a/docs/ex6_bios_revert_default.rest
+++ b/docs/ex6_bios_revert_default.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 6: Revert to default BIOS setting
 =========================================
 
-The method **ex6_bios_revert_default** takes an instance of rest object (or redfish object if using redfish API) as parameter.
+The method **ex6_bios_revert_default** takes an instance of rest object (or
+redfish object if using redfish API) as parameter.
 
 .. code-block:: python
 
@@ -46,6 +51,9 @@ PUT request is performed next and response error is handled if any.
  response = restobj.rest_put(instance["href"], body)
  restobj.error_handler(response)
 
-A successful PUT response implies that BIOS is set to default settings, however the changes will get affected only after a system reset or reboot.
+A successful PUT response implies that BIOS is set to default settings, however
+the changes will get affected only after a system reset or reboot.
 
-**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the example includes Redfish implementation for Redfish Bios. type support in Gen10. Rest works as intended.
+**Note:** The Bios. type is not supported in Gen9 servers for Redfish but the
+example includes Redfish implementation for Redfish Bios. type support in
+Gen10. Rest works as intended.

--- a/docs/ex7_change_boot_order.rest
+++ b/docs/ex7_change_boot_order.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,13 +24,16 @@ Redfish Object creation:
 Example 7: Change UEFI boot order
 =================================
 
-The method **ex7_change_boot_order** takes an instance of rest object (or redfish object if using Redfish API) and BIOS password (default None) as arguments.
+The method **ex7_change_boot_order** takes an instance of rest object (or
+redfish object if using Redfish API) and BIOS password (default None) as
+arguments.
 
 .. code-block:: python
 
  def ex7_change_boot_order(restobj, bios_password=None):
 
-Find and get the server boot settings URI(s) from the system resource collection.
+Find and get the server boot settings URI(s) from the system resource
+collection.
 
 .. code-block:: python
 
@@ -59,4 +66,5 @@ PATCH request is sent next and response error is handled if any.
  response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
  restobj.error_handler(response)
 
-A successful PATCH response will set the Boot order in BIOS, however the settings remain pending until next reboot.
+A successful PATCH response will set the Boot order in BIOS, however the
+settings remain pending until next reboot.

--- a/docs/ex7_change_boot_order.rest
+++ b/docs/ex7_change_boot_order.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,56 +11,39 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 7: Change UEFI boot order
 =================================
 
-The method **ex7_change_boot_order** takes an instance of rest object (or redfish object if using Redfish API) and BIOS  password (default None) as arguments.
-
-
-.. code-block:: python
-
-
-    def ex7_change_boot_order(restobj, bios_password=None):
-
-
-::
-
-
-Find and get the server boot settings URI(s) from the system resource collection. 
+The method **ex7_change_boot_order** takes an instance of rest object (or redfish object if using Redfish API) and BIOS password (default None) as arguments.
 
 .. code-block:: python
 
+ def ex7_change_boot_order(restobj, bios_password=None):
 
-     instances = restobj.search_for_type("ServerBootSettings.1")
+Find and get the server boot settings URI(s) from the system resource collection.
 
-::
+.. code-block:: python
+
+ instances = restobj.search_for_type("ServerBootSettings.1")
 
 Send a HTTP GET request to the server boot settings URI(s) retrieved.
 
 .. code-block:: python
 
  for instance in instances:
-        response = restobj.rest_get(instance["href"])
-
-::
+     response = restobj.rest_get(instance["href"])
 
 Get the boot order from the response body.
 
 .. code-block:: python
  
-  bootorder = response.dict["PersistentBootConfigOrder"]
-
+ bootorder = response.dict["PersistentBootConfigOrder"]
 
 Set up PATCH request body.
 
@@ -70,18 +52,11 @@ Set up PATCH request body.
  body = dict()
  body["PersistentBootConfigOrder"] = bootorder
 
-::
-
-
- 
 PATCH request is sent next and response error is handled if any.
 
 .. code-block:: python
 
-        response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)            
-        restobj.error_handler(response)
+ response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
+ restobj.error_handler(response)
 
-::
-
-
-A successful PATCH response will set the Boot order  in BIOS, however the settings remain pending until next reboot.
+A successful PATCH response will set the Boot order in BIOS, however the settings remain pending until next reboot.

--- a/docs/ex8_change_temporary_boot_order.rest
+++ b/docs/ex8_change_temporary_boot_order.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,9 @@ Redfish Object creation:
 Example 8: Change temporary boot order
 ======================================
 
-The method **ex8_change_temporary_boot_order** takes an instance of rest object (or redfish object if using Redfish API), boot target and BIOS password (default None) as arguments.
+The method **ex8_change_temporary_boot_order** takes an instance of rest object
+(or redfish object if using Redfish API), boot target and BIOS password
+(default None) as arguments.
 
 .. code-block:: python
 
@@ -39,7 +45,8 @@ Send a HTTP GET request to the  systems URI(s) retrieved.
  for instance in instances:
      response = restobj.rest_get(instance["href"])
 
-Get the supported boot options from the response body and check if the boot target provided as argument is supported.
+Get the supported boot options from the response body and check if the boot
+target provided as argument is supported.
 
 .. code-block:: python
  
@@ -63,4 +70,5 @@ PATCH request is sent next and response error is handled if any.
  response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
  restobj.error_handler(response)
 
-A successful PATCH response will set the Boot order in BIOS, however the settings remain pending until next reboot.
+A successful PATCH response will set the Boot order in BIOS, however the
+settings remain pending until next reboot.

--- a/docs/ex8_change_temporary_boot_order.rest
+++ b/docs/ex8_change_temporary_boot_order.rest
@@ -1,10 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
+
 |
-
-
-
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -14,59 +11,42 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
-
 Example 8: Change temporary boot order
 ======================================
 
-The method **ex8_change_temporary_boot_order** takes an instance of rest object (or redfish object if using Redfish API), boot target and BIOS  password (default None) as arguments.
-
-
-.. code-block:: python
-
-
-    def ex8_change_temporary_boot_order(restobj, boottarget, bios_password=None):
-
-
-::
-
-
-Find and get the system URI(s) from the system resource collection. 
+The method **ex8_change_temporary_boot_order** takes an instance of rest object (or redfish object if using Redfish API), boot target and BIOS password (default None) as arguments.
 
 .. code-block:: python
 
+ def ex8_change_temporary_boot_order(restobj, boottarget, bios_password=None):
 
-     instances = restobj.search_for_type("ComputerSystem.")
+Find and get the system URI(s) from the system resource collection.
 
-::
+.. code-block:: python
+
+ instances = restobj.search_for_type("ComputerSystem.")
 
 Send a HTTP GET request to the  systems URI(s) retrieved.
 
 .. code-block:: python
 
  for instance in instances:
-        response = restobj.rest_get(instance["href"])
-
-::
+     response = restobj.rest_get(instance["href"])
 
 Get the supported boot options from the response body and check if the boot target provided as argument is supported.
 
 .. code-block:: python
  
-  bootoptions = response.dict["Boot"]
-        
-  if boottarget not in bootoptions["BootSourceOverrideSupported"]:
-            sys.stderr.write("ERROR: %s is not a supported boot option.\n" % boottarget)
+ bootoptions = response.dict["Boot"]
+
+ if boottarget not in bootoptions["BootSourceOverrideSupported"]:
+     sys.stderr.write("ERROR: %s is not a supported boot option.\n" % boottarget)
 
 Prepare the PATCH request body.
 
@@ -76,19 +56,11 @@ Prepare the PATCH request body.
  body["Boot"] = dict()
  body["Boot"]["BootSourceOverrideTarget"] = boottarget
 
-::
-
-
- 
 PATCH request is sent next and response error is handled if any.
 
 .. code-block:: python
 
-        response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)            
-        restobj.error_handler(response)
+ response = restobj.rest_patch(instance["href"], body, optionalpassword=bios_password)
+ restobj.error_handler(response)
 
-::
-
-
-A successful PATCH response will set the Boot order  in BIOS, however the settings remain pending until next reboot.
-
+A successful PATCH response will set the Boot order in BIOS, however the settings remain pending until next reboot.

--- a/docs/ex9_find_ilo_mac_address.rest
+++ b/docs/ex9_find_ilo_mac_address.rest
@@ -1,8 +1,7 @@
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
 
+|
 
 First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
 
@@ -12,69 +11,48 @@ Rest Object creation:
 
  REST_OBJ = RestObject(iLO_https_host, login_account, login_password)
 
-::
-
 Redfish Object creation:
 
 .. code-block:: python
 
  REDFISH_OBJ = RedfishObject(iLO_https_host, login_account, login_password)
 
-::
-
-
 Example 9: Find iLO mac address
 ===============================
 
 The method **ex9_find_ilo_mac_address** takes an instance of rest object (or redfish object if using Redfish API) as argument.
 
+.. code-block:: python
+
+ def ex9_find_ilo_mac_address(restobj):
+
+Find and get the system resource for manager.
 
 .. code-block:: python
 
+ instances = restobj.search_for_type("Manager.")
 
-    def ex9_find_ilo_mac_address(restobj):
-
-
-::
-
-Find and get the system resource for manager. 
-
-.. code-block:: python
-
-
-     instances = restobj.search_for_type("Manager.")
-
-::
-
-Send a HTTP GET request to the  manager URI(s). 
+Send a HTTP GET request to the  manager URI(s).
 
 .. code-block:: python
 
  for instance in instances:
-        tmp = restobj.rest_get(instance["href"])
-
-::
+     tmp = restobj.rest_get(instance["href"])
 
 Ethernet interfaces URI link found from the response body is used for another GET request.
 
 .. code-block:: python
-
-  
-   response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
-
-::
+ 
+ response = restobj.rest_get(tmp.dict["links"]["EthernetNICs"]["href"])
 
 Check the response for Mac addresses, if found print it.
 
 .. code-block:: python
 
-   for item in response.dict["Items"]:
-            if "MacAddress" not in item:
-                sys.stderr.write("\tNIC resource does not contain " \
-                                                    "'MacAddress' property\n")
-            else:
-                sys.stdout.write("\t" + item["Name"] + " = " + \
-                                             item["MacAddress"] + "\t(" + \
-                                             item["Status"]["State"] + ")\n")
-::
-
+ for item in response.dict["Items"]:
+     if "MacAddress" not in item:
+         sys.stderr.write("\tNIC resource does not contain 'MacAddress' property\n")
+     else:
+         sys.stdout.write("\t" + item["Name"] + " = " + \
+                          item["MacAddress"] + "\t(" + \
+                          item["Status"]["State"] + ")\n")

--- a/docs/ex9_find_ilo_mac_address.rest
+++ b/docs/ex9_find_ilo_mac_address.rest
@@ -3,7 +3,11 @@
 
 |
 
-First create an instance of Rest or Redfish Object using the  **RestObject** or **RedfishObject** class respectively. The class constructor takes iLO hostname/ ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username and password as arguments. The class also initializes a login session, gets systems resources and message registries.
+First create an instance of Rest or Redfish Object using the **RestObject** or
+**RedfishObject** class respectively. The class constructor takes iLO hostname/
+ip address formatted as a string ("https://xx.xx.xx.xx"), iLO login username
+and password as arguments. The class also initializes a login session, gets
+systems resources and message registries.
 
 Rest Object creation:
 
@@ -20,7 +24,8 @@ Redfish Object creation:
 Example 9: Find iLO mac address
 ===============================
 
-The method **ex9_find_ilo_mac_address** takes an instance of rest object (or redfish object if using Redfish API) as argument.
+The method **ex9_find_ilo_mac_address** takes an instance of rest object (or
+redfish object if using Redfish API) as argument.
 
 .. code-block:: python
 
@@ -39,7 +44,8 @@ Send a HTTP GET request to the  manager URI(s).
  for instance in instances:
      tmp = restobj.rest_get(instance["href"])
 
-Ethernet interfaces URI link found from the response body is used for another GET request.
+Ethernet interfaces URI link found from the response body is used for another
+GET request.
 
 .. code-block:: python
  

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,24 +2,21 @@
    sphinx-quickstart on Fri Mar 11 11:34:15 2016.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
-   
+
 .. image:: /images/hpe_logo2.png
    :width: 150pt
-   
-|
-|
 
 Python iLO RESTful Library
-===============
+==========================
 
-The Python iLO RESTful library is the platform on which the HPE RESTful tool was built on. It's main purpose is to simplify  the inband and outband communication to the HPE RESTful API.The HPE RESTful API for iLO is a RESTful application programming interface for the management of iLO and iLO Chassis Manager based HPE servers. REST (Representational State Transfer) is a web based software architectural style consisting a set of constraints that focus on a system's resource. HPE REST library performs the basic HTTP operations GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as the Engine of Application) REST architecture. The API allows the clients to manage and interact with iLO through a fixed URL and several URIs. Go to the `API overview <API-Overview.html>`_ section for more details.
+The Python iLO RESTful library is the platform on which the HPE RESTful tool was built on. It's main purpose is to simplify the inband and outband communication to the HPE RESTful API. The HPE RESTful API for iLO is a RESTful application programming interface for the management of iLO and iLO Chassis Manager based HPE servers. REST (Representational State Transfer) is a web based software architectural style consisting a set of constraints that focus on a system's resource. HPE REST library performs the basic HTTP operations GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as the Engine of Application) REST architecture. The API allows the clients to manage and interact with iLO through a fixed URL and several URIs. Go to the `API overview <API-Overview.html>`_ section for more details.
 
 Documentation
 -------------
 
 .. toctree::
    :maxdepth: 1
-   
+
    API-Overview
    Installation-Guide
    Downloading-the-Code
@@ -31,7 +28,7 @@ Documentation
 Mailing list
 -------------
 
-| Join the <Google groups link> to discuss and get support from the community and team. 
+| Join the <Google groups link> to discuss and get support from the community and team.
 |
 
 Get in touch with the team
@@ -47,7 +44,6 @@ If you have further questions, please contact the team:
 * `Kevin Chang <http://github.com/kckaiwei>`_
 
 Contributors
--------------
+------------
 
 Contributors are listed `here <../../python-ilorest-library/graphs/contributors>`_.
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Documentation
 .. toctree::
    :maxdepth: 1
 
+   Overview
    API-Overview
    Installation-Guide
    Downloading-the-Code

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,17 @@
 Python iLO RESTful Library
 ==========================
 
-The Python iLO RESTful library is the platform on which the HPE RESTful tool was built on. It's main purpose is to simplify the inband and outband communication to the HPE RESTful API. The HPE RESTful API for iLO is a RESTful application programming interface for the management of iLO and iLO Chassis Manager based HPE servers. REST (Representational State Transfer) is a web based software architectural style consisting a set of constraints that focus on a system's resource. HPE REST library performs the basic HTTP operations GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as the Engine of Application) REST architecture. The API allows the clients to manage and interact with iLO through a fixed URL and several URIs. Go to the `API overview <API-Overview.html>`_ section for more details.
+The Python iLO RESTful library is the platform on which the HPE RESTful tool
+was built on. It's main purpose is to simplify the inband and outband
+communication to the HPE RESTful API. The HPE RESTful API for iLO is a RESTful
+application programming interface for the management of iLO and iLO Chassis
+Manager based HPE servers. REST (Representational State Transfer) is a web
+based software architectural style consisting a set of constraints that focus
+on a system's resource. HPE REST library performs the basic HTTP operations
+GET, POST, PUT, PATCH and DELETE on resources using the HATEOS (Hypermedia as
+the Engine of Application) REST architecture. The API allows the clients to
+manage and interact with iLO through a fixed URL and several URIs. Go to the
+`API overview <API-Overview.html>`_ section for more details.
 
 Documentation
 -------------


### PR DESCRIPTION
Hi,

I've intended to package the library python-ilorest for Debian, please see my [ITP](https://bugs.debian.org/903953).
To prevent some Lintian warnings, Lintian is a packaging QS tool, I've looked into the existing docs/ folder and found a lot of Sphinx warnings which are easily to solve.
```
$ make html
sphinx-build -b html -d .build/doctrees   . .build/html
Running Sphinx v1.7.5
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 56 source files that are out of date
updating environment: 56 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                  
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:38: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:50: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:60: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:72: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:87: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:103: WARNING: Literal block expected; none found.
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:104: WARNING: Title underline too short.

Building and installing HP REST library
===================================
/home/carsten/gitprojects/python-ilorest-library/docs/Installation-Guide.rest:104: WARNING: Title underline too short.
...
```
I've reworked the existing files and cleaned up all Sphinx messages so far. I removed any trailing white spaces or empty and useless lines. Also normalized all code blocks to have just one character to mark them as a code block. The underlining are fixed in various places so Sphinx is happy. The Python code fragments got a proper consistent intention by 4 spaces so people can do copy and paste.

Finally I did a line break on 78 characters as usual in such files for better readability. I removed some double spaces within some sentences also by this.

I checked the output of my changes to the old existing files and it looks good to me.