### PR TITLE
Fix getting attributes of a RisObject instance

### DIFF
--- a/src/redfish/rest/containers.py
+++ b/src/redfish/rest/containers.py
@@ -69,13 +69,20 @@ class RisObject(dict):
     :param d: dictionary to be converted
     :type d: dict
     """
-    __getattr__ = dict.__getitem__
-
     def __init__(self, d):
         """Initialize RisObject
         """
         super(RisObject, self).__init__()
         self.update(**dict((k, self.parse(value)) for k, value in list(d.items())))
+
+    def __getattr__(self, k):
+        try:
+            return self[k]
+        except KeyError:
+            raise AttributeError(
+                "type object '%s' has no attribute '%s'" %
+                (self.__class__.__name__, k)
+            )
 
     @classmethod
     def parse(cls, value):


### PR DESCRIPTION
When getting a nonexistent attribute of a RisObject instance,
instead of an AttributeError exception, a KeyError exception is raised.
This is not an expected behaviour.

Example:

```
import redfish

SYSTEM_URL = "https://10.0.0.100"
LOGIN_ACCOUNT = "admin"
LOGIN_PASSWORD = "password"

REDFISH_OBJ = redfish.RedfishClient(
    base_url=SYSTEM_URL,
    username=LOGIN_ACCOUNT,
    password=LOGIN_PASSWORD
)

REDFISH_OBJ.login()

RESPONSE = REDFISH_OBJ.get("/redfish/v1/systems/1")

RESPONSE_OBJ = RESPONSE.obj

print(RESPONSE_OBJ.NonExistingAttr)
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call
last)
<ipython-input-6-a41dd91fc6ac> in <module>
----> 1 print(RESPONSE_OBJ.NonExistingAttr)

KeyError: 'NonExistingAttr'
```