### PR TITLE
update_ilo_firmware.py

### DIFF
--- a/examples/Redfish/update_ilo_firmware.py
+++ b/examples/Redfish/update_ilo_firmware.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     FIRMWARE_URL = "http://<url_to_binary_file>"
     # If a TPM module (Trusted Platform Module/ Cryptographic Co-processor) is installed/present
     # onboard then be sure to include this.
-    TPM_FLAG = True
+    TPM_FLAG = False
     # flag to force disable resource directory. Resource directory and associated operations are
     # intended for HPE servers.
     DISABLE_RESOURCE_DIR = True


### PR DESCRIPTION
TPM flag is only considered (True or False) when updating the Firmware via OEM url and not the  default simple update url which is default redfish standard.

redfish standard Url : redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate/  

###############below is the data when TPM_FLAG = True##############

Found resource directory at /redfish/v1/resourcedirectory

[
    {
        "MessageArgs": [
            "UpdateService.SimpleUpdate", 
            "TPMOverrideFlag"
        ], 
        "MessageId": "Base.1.4.ActionParameterUnknown"
    }
]
>>> 

#########below is the data when TPM_FLAG = False#####################

	Found resource directory at /redfish/v1/resourcedirectory

Success!

[
    {
        "MessageId": "Base.1.4.Success"
    }
]