### PR TITLE
Fix broken links in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,9 +82,9 @@ It must be placed in your working environment path.
 
 Usage
 ----------
-For 3.x and greater versions of the library see the documentation for usage: https://pages.github.hpe.com/intelligent-provisioning/python-redfish-library/
+For 3.x and greater versions of the library see the documentation for usage: https://hewlettpackard.github.io/python-ilorest-library/
 
-For 2.x versions of the library documentation is located at the `Wiki <https://github.hpe.com/intelligent-provisioning/python-redfish-library/wiki>`_.
+For 2.x versions of the library documentation is located at the `Wiki <https://github.com/HewlettPackard/python-ilorest-library/wiki>`_.
 
 Contributing
 ----------


### PR DESCRIPTION
## Additional High Level Description
Fix broken links in usage section of README.rst
Closes #108.


## Before Status can be set to READY I have completed the following:
- [x] Check if documentation updates
- [x] Check if example code updates
- [x] Pylint static analysis tests are passing above 9.0/10.0
- [x] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
