### PR TITLE
rest: Check that ca_cert_data is not None

### DIFF
--- a/src/redfish/rest/connections.py
+++ b/src/redfish/rest/connections.py
@@ -86,7 +86,7 @@ class HttpConnection(object):
         self._conn = None
         self.base_url = base_url
         self._connection_properties = client_kwargs
-        if 'cert_file' in cert_data and cert_data['cert_file']:
+        if cert_data and 'cert_file' in cert_data and cert_data['cert_file']:
             self._connection_properties.update({'ca_cert_data':cert_data})
         self._proxy = self._connection_properties.pop('proxy', None)
         self.session_key = self._connection_properties.pop('session_key', None)

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -229,7 +229,7 @@ class RestClient(RestClientBase):
             Defaults to session auth."""
         if not auth_param:
             #_ca_cert_data = client_kwargs.get('ca_cert_data')
-            if 'cert_file' in ca_cert_data and ca_cert_data['cert_file']:
+            if ca_cert_data and 'cert_file' in ca_cert_data and ca_cert_data['cert_file']:
                 if ca_cert_data.get('cert_file') and ca_cert_data.get('key_file'):
                     return AuthMethod.CERTIFICATE
             return AuthMethod.SESSION


### PR DESCRIPTION
The default value of this variable is `None` but you can't check `foo in None`:

```
root@9f485191af50:/# /redfish/upload_firmware_ilo_repository.py 
Traceback (most recent call last):
  File "/redfish/upload_firmware_ilo_repository.py", line 103, in <module>
    REDFISHOBJ = RedfishClient(base_url=SYSTEM_URL, username=LOGIN_ACCOUNT, \
  File "/usr/local/lib/python3.9/site-packages/redfish/rest/v1.py", line 481, in __init__
    super(RedfishClient, self).__init__(default_prefix='/redfish/v1/', is_redfish=True,
  File "/usr/local/lib/python3.9/site-packages/redfish/rest/v1.py", line 211, in __init__
    self.auth_type = self._get_auth_type(auth, ca_cert_data=ca_cert_data, **client_kwargs)
  File "/usr/local/lib/python3.9/site-packages/redfish/rest/v1.py", line 232, in _get_auth_type
    if 'cert_file' in ca_cert_data and ca_cert_data['cert_file']:
TypeError: argument of type 'NoneType' is not iterable
```



-----Synopsis of Commits Above-----

**Please fill out the following when submitting the PR**

## Status
- [x] READY 
- [ ] IN-DEVELOPMENT 
- [ ] ON-HOLD

## Additional High Level Description
A few sentences describing the overall goals of the pull request's commits.
- Include the issue number here if it fixes one. Example `#1`
- Include the QUIX number here if it fixes one.

## Dependent PRs
List any PRs that must be merged together. (Tool dependent PRs SHOULD NOT occur.)
- If additional library PRs are to be referenced simply note the PR# 

## Before Status can be set to READY I have completed the following:
- [x] Check if documentation updates
- [x] Check if example code updates
- [x] Pylint static analysis tests are passing above 9.0/10.0
- [x] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
