### PR TITLE
Fix collections import in Utils.py to work on python 3

### DIFF
--- a/src/redfish/ris/utils.py
+++ b/src/redfish/ris/utils.py
@@ -25,7 +25,9 @@ import logging
 if six.PY3:
     from functools import reduce
 
-from collections import Mapping
+if six.PY2:
+    from collections import Mapping
+from collections.abc import Mapping
 
 import jsonpath_rw
 


### PR DESCRIPTION
When running on Python 3.10 Line 28 -> 'from collections import Mapping' raises exception as collections modules has been changed from python 2 to python 3. Changes tested to work on both python2 and python 3
-----Synopsis of Commits Above-----

**Please fill out the following when submitting the PR**

## Status
- [x] READY 
- [ ] IN-DEVELOPMENT 
- [ ] ON-HOLD

## Additional High Level Description
When running on Python 3.10 Line 28 -> 'from collections import Mapping' raises exception as collections modules has been changed from python 2 to python 3

## Dependent PRs
none

## Before Status can be set to READY I have completed the following:
- [x] Check if documentation updates
- [x] Check if example code updates
- [ ] Pylint static analysis tests are passing above 9.0/10.0
- [ ] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
