### PR TITLE
fix/string encode compatibility

### DIFF
--- a/src/redfish/rest/connections.py
+++ b/src/redfish/rest/connections.py
@@ -164,7 +164,7 @@ class HttpConnection(object):
         files = None
         request_args = {}
         if isinstance(path, bytes):
-            path = str(path, "utf-8")
+            path = str(path).encode("utf-8")
             external_uri = True if 'redfish.dmtf.org' in path else False
         else:
             external_uri = True if 'redfish.dmtf.org' in path else False


### PR DESCRIPTION
trivial string encoding fix for Python2 compatibility

test script:
```
from redfish import RedfishClient

rf = RedfishClient(base_url='https://16.1.15.1', username='Administrator', password='password')
rf.login()
```


test script no longer fails with `TypeError: str() takes at most 1 argument (2 given)`


## Status
- [x] READY 
- [ ] IN-DEVELOPMENT 
- [ ] ON-HOLD

## Additional High Level Description
A few sentences describing the overall goals of the pull request's commits.
- Include the issue number here if it fixes one. Example `#1`
- Include the QUIX number here if it fixes one.

## Dependent PRs
List any PRs that must be merged together. (Tool dependent PRs SHOULD NOT occur.)
- If additional library PRs are to be referenced simply note the PR# 

## Before Status can be set to READY I have completed the following:
- [ ] Check if documentation updates
- [ ] Check if example code updates
- [ ] Pylint static analysis tests are passing above 9.0/10.0
- [ ] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
