### PR TITLE
Highlight hpilo kernel module requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,8 @@ It must be placed in your working environment path.
  .. _ilorest_chif.dll: https://github.com/HewlettPackard/python-ilorest-library/releases/tag/v3.6.0.0/ilorest_chif.dll
  .. _ilorest_chif.so: https://github.com/HewlettPackard/python-ilorest-library/releases/tag/v3.6.0.0/ilorest_chif.so
 
+For Linux, the `hpilo` kernel module must be loaded as well.
+
 Usage
 ----------
 For usage documentation: https://hewlettpackard.github.io/python-ilorest-library/API-Overview.html

--- a/src/redfish/hpilo/rishpilo.py
+++ b/src/redfish/hpilo/rishpilo.py
@@ -135,7 +135,9 @@ class HpIlo(object):
                 if status != BlobReturnCodes.SUCCESS:
                     errmsg = "Error {0} occurred while trying to open a " "channel to iLO".format(status)
                     if status == BlobReturnCodes.CHIFERR_NoDriver:
-                        errmsg = "chif"
+                        errmsg = "No devices were found."
+                        if os.name != "nt":
+                            errmsg = f"{errmsg} Ensure the hpilo kernel module is loaded."
                     elif status == BlobReturnCodes.CHIFERR_AccessDenied:
                         errmsg = "You must be root/Administrator to use this program."
                     raise HpIloInitialError(errmsg)


### PR DESCRIPTION
The ilorest_chif.so library seems to handle a lack of the "hpilo" kernel module the same way as a lack of iLO devices, returning "No hpilo devices found" with status 19.
This being converted to a "chif" error causes a misleading "Chif driver not found" message if the application is executed on a Linux system having the Chif driver installed, but not having the "hpilo" module loaded.
At the point the message is printed, the library was already loaded, indicating it must be correctly present, otherwise it would not have been able to return an error code.
Improve user guidance by instead setting an error message similar to the one returned by the library itself, but also pointing out the need for the hpilo kernel module if not executed on Windows. Additionally, highlight this requirement in the README.



-----Synopsis of Commits Above-----

**Please fill out the following when submitting the PR**

## Status
- [x] READY 
- [ ] IN-DEVELOPMENT 
- [ ] ON-HOLD

## Additional High Level Description
A few sentences describing the overall goals of the pull request's commits.
- Include the issue number here if it fixes one. Example `#1`
- Include the QUIX number here if it fixes one.

## Dependent PRs
List any PRs that must be merged together. (Tool dependent PRs SHOULD NOT occur.)
- If additional library PRs are to be referenced simply note the PR# 

## Before Status can be set to READY I have completed the following:
- [x] Check if documentation updates
- [x] Check if example code updates
- [ ] Pylint static analysis tests are passing above 9.0/10.0
- [ ] Unit tests added for any new functions/features and passed.
- [x] Targeted/Custom Testing performed. Indicate the results in the description above or as additional comments.
