### PR TITLE
Package in ilorest-lib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(name='python-ilorest-library',
           'Topic :: Communications'
       ],
       keywords='Hewlett Packard Enterprise',
-      url='https://github.com/HewlettPackard/python-ilorest-library',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
+      url='https://github.com/HewlettPackard/python-ilorest-library'
+      packages=['ilorest-lib'] + [f'ilorest-lib.{p}' for p in find_packages('src/redfish') if p != ''],
+      package_dir={'ilorest-lib': 'src/redfish'},,
       install_requires=[
           'jsonpatch',
           'jsonpath_rw',


### PR DESCRIPTION
Current, this package uses "redfish" as namespace. Unfortunately, this clashes with this Python module:

https://pypi.org/project/redfish/

This patch moves away from "redfish" to "ilorest-lib". Of course, another patch will be needed in python-redfish-utility to use this new namespace.
